### PR TITLE
Update start_liquidity default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Además soporta la conexión con otros exchanges opcionalmente y dispone de un p
 - Historial persistente de operaciones en `trade_history.csv` y archivos JSON
 - Endpoints públicos de Binance para ticker, libro de órdenes y velas
 - Flujo en tiempo real del order book por `wss://fstream.binance.com`
-- Los WebSocket se inician explícitamente con `strategy.start_liquidity()` para evitar conexiones al importar módulos
+- Los WebSocket se inician explícitamente con `strategy.start_liquidity()` para evitar conexiones al importar módulos. Sin pasar símbolos se conectará automáticamente a los 15 pares de mayor volumen
 - Modelos de machine learning optimizados con `trading_bot.optimizer`
 - Entrenamiento de modelos con `python -m trading_bot.train_model`
 - Exchange simulado para pruebas sin conexión a Bitget

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -192,7 +192,10 @@ SYMBOLS = ["BTC/USDT", "ETH/USDT"]
 
 def start_liquidity(symbols=None):
     """Start the liquidity websocket listeners when running the bot."""
-    liquidity_ws.start(symbols or SYMBOLS)
+    if symbols is None:
+        liquidity_ws.start()
+    else:
+        liquidity_ws.start(symbols)
 
 def print_liquidity():
     """Example function showing how to query liquidity data."""


### PR DESCRIPTION
## Summary
- allow `strategy.start_liquidity()` to use the top 15 symbols
- clarify README about the automatic symbol list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python -m trading_bot.bot --help` *(fails: server rejected WebSocket connection)*

------
https://chatgpt.com/codex/tasks/task_e_6877881b5a808333b4a777580c52afbe