### PR TITLE
Fix trailing text in liquidity_ws

### DIFF
--- a/trading_bot/liquidity_ws.py
+++ b/trading_bot/liquidity_ws.py
@@ -21,7 +21,7 @@ DEFAULT_TOP_15_SYMBOLS = [
 ]
 
 
-def get_top_15_symbols() -> list[str]:re
+def get_top_15_symbols() -> list[str]:
     """Return the 15 highest volume USDT futures symbols."""
     ex = exchanges.get_exchange(config.DEFAULT_EXCHANGE)
     symbols = data.get_common_top_symbols(ex, 15)


### PR DESCRIPTION
## Summary
- correct function annotation syntax for `get_top_15_symbols`

## Testing
- `python -m py_compile trading_bot/liquidity_ws.py`


------
https://chatgpt.com/codex/tasks/task_e_6881f56c88048333af9767966ac321d0