### PR TITLE
Improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ variables definidas en `trading_bot/config.py`:
 
 Copia `.env.example` a `.env` y rellena tus claves API para comenzar. El bot
 cargará automáticamente ese archivo al iniciarse.
+## Pruebas
+
+Para ejecutar todas las pruebas y ver el reporte de cobertura ejecuta:
+
+```bash
+pytest
+```
+
 
 ## Licencia
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra --cov=trading_bot --cov-report=term-missing
+testpaths = tests

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import data
+
+
+def test_get_market_data_uses_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(data, "CACHE_DIR", cache_dir.as_posix())
+
+    symbol = "BTC_USDT"
+    interval = "Min15"
+    limit = 5
+    sample = {"close": ["1"], "high": ["2"], "low": ["0"], "vol": ["10"]}
+    os.makedirs(cache_dir, exist_ok=True)
+    with open(cache_dir / f"{symbol.replace('_','')}_{interval}_{limit}.json", "w", encoding="utf-8") as fh:
+        json.dump(sample, fh)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("net down")
+
+    monkeypatch.setattr(data.requests, "get", fail)
+    monkeypatch.setattr(data.time, "sleep", lambda x: None)
+
+    result = data.get_market_data(symbol, interval=interval, limit=limit)
+    assert result == sample
+

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import execution
+from trading_bot.exchanges import MockExchange
+
+
+def test_open_and_close_position_success(monkeypatch):
+    ex = MockExchange()
+    monkeypatch.setattr(execution, "exchange", ex)
+    monkeypatch.setattr(execution.time, "sleep", lambda x: None)
+
+    order = execution.open_position("BTC_USDT", "BUY", 1, 30000, order_type="market")
+    assert order["side"] == "buy"
+
+    close = execution.close_position("BTC_USDT", "close_long", 1, order_type="market")
+    assert close["side"] == "sell"
+
+
+def test_open_position_retry_failure(monkeypatch):
+    ex = MockExchange()
+    monkeypatch.setattr(execution, "exchange", ex)
+    monkeypatch.setattr(execution.time, "sleep", lambda x: None)
+
+    def always_fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ex, "create_order", always_fail)
+
+    with pytest.raises(execution.OrderSubmitError):
+        execution.open_position("BTC_USDT", "BUY", 1, 30000, order_type="market")
+
+
+def test_close_position_retry_success(monkeypatch):
+    ex = MockExchange()
+    monkeypatch.setattr(execution, "exchange", ex)
+    monkeypatch.setattr(execution.time, "sleep", lambda x: None)
+
+    original_create = ex.create_order
+    calls = {"n": 0}
+
+    def fail_once(*args, **kwargs):
+        if calls["n"] == 0:
+            calls["n"] += 1
+            raise RuntimeError("temp")
+        return original_create(*args, **kwargs)
+
+    monkeypatch.setattr(ex, "create_order", fail_once)
+
+    execution.open_position("BTC_USDT", "BUY", 1, 30000, order_type="market")
+    order = execution.close_position("BTC_USDT", "close_long", 1, order_type="market")
+    assert order["side"] == "sell"
+

--- a/tests/test_strategy_size.py
+++ b/tests/test_strategy_size.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from trading_bot import strategy
+
+
+def test_calcular_tamano_atr_zero():
+    size = strategy.calcular_tamano_posicion(
+        balance_usdt=1000,
+        entry_price=100,
+        atr_value=0,
+        atr_multiplier=1.5,
+        risk_per_trade_usd=10,
+    )
+    assert size == 0.0
+
+
+def test_calcular_tamano_distancia_negativa():
+    size = strategy.calcular_tamano_posicion(
+        balance_usdt=1000,
+        entry_price=100,
+        atr_value=1,
+        atr_multiplier=-1,
+        risk_per_trade_usd=10,
+    )
+    assert size == 0.0
+
+
+def test_calcular_tamano_capped_by_balance():
+    size = strategy.calcular_tamano_posicion(
+        balance_usdt=100,
+        entry_price=10,
+        atr_value=0.5,
+        atr_multiplier=1,
+        risk_per_trade_usd=1000,
+    )
+    # Available balance only allows 10 contracts
+    assert size == pytest.approx(10)
+


### PR DESCRIPTION
## Summary
- add more unit and integration tests
- add cached data test
- configure pytest with coverage
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883499170b08333ab89257aca011c0e