### PR TITLE
Improve resilience for data retrieval and order handling

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -75,3 +75,9 @@ RISK_PER_TRADE = float(os.getenv("RISK_PER_TRADE", "0.01"))
 ENABLE_TRADE_HISTORY_LOG = os.getenv("ENABLE_TRADE_HISTORY_LOG", "0") == "1"
 MAX_TRADE_HISTORY_SIZE = int(os.getenv("MAX_TRADE_HISTORY_SIZE", "1000"))
 
+# Number of times to retry data fetch operations before falling back to cache
+DATA_RETRY_ATTEMPTS = int(os.getenv("DATA_RETRY_ATTEMPTS", "3"))
+
+# Maximum attempts when submitting or closing orders
+ORDER_SUBMIT_ATTEMPTS = int(os.getenv("ORDER_SUBMIT_ATTEMPTS", "3"))
+


### PR DESCRIPTION
## Summary
- add retry constants to `config`
- implement exponential backoff and disk caching for HTTP/ccxt calls in `data.py`
- validate order responses and retry submission in `execution.py`
- skip cancelling non-open orders

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883496a1944833388ae315922903559