### PR TITLE
Fix LOG_LEVEL configuration

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -23,6 +23,8 @@ MEXC_API_SECRET = get_secret("MEXC_API_SECRET") or ""
 
 DEFAULT_EXCHANGE = os.getenv("DEFAULT_EXCHANGE", "bitget")
 
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
 TEST_MODE = os.getenv("TEST_MODE", "0") == "1"
 # Optional comma separated list of symbols to analyze when TEST_MODE is enabled
 _test_syms = os.getenv("TEST_SYMBOLS", "")


### PR DESCRIPTION
## Summary
- add LOG_LEVEL setting to configuration so bot.py can always read it

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-cov`
- `pytest -q` *(fails: AttributeError in tests and missing async plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68894de0a6588333aea6e95669006791