### PR TITLE
Fix missing normalize_symbol import

### DIFF
--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -10,6 +10,7 @@ from threading import Thread
 from datetime import datetime, timedelta
 
 import pandas as pd
+from .utils import normalize_symbol
 
 from . import (
     config,

--- a/trading_bot/trade_manager.py
+++ b/trading_bot/trade_manager.py
@@ -30,6 +30,15 @@ def normalize_symbol(symbol: str) -> str:
     base = raw[:-4]
     return f"{base}_USDT"
 
+
+def reset_state() -> None:
+    """Clear all in-memory trade state for tests."""
+    with LOCK:
+        open_trades.clear()
+        closed_trades.clear()
+        trade_history.clear()
+        _last_closed.clear()
+
 # --- Core functions ---
 
 def add_trade(trade):


### PR DESCRIPTION
## Summary
- import `normalize_symbol` utility in `bot.py`
- add `reset_state` helper to trade manager for tests

## Testing
- `pytest -q` *(fails: AttributeError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6889ddf2538883338a0b5ed0323a2723