### PR TITLE
ci: ensure async tests run on GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install pytest pytest-cov flake8 mypy codecov
+          python -m pip install -U pip
+          pip install -e .
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
       - name: Run tests with coverage
         run: pytest -q --cov=trading_bot

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ addopts =
 testpaths = tests
 python_files = test_*.py
 xfail_strict = true
+asyncio_mode = auto
 
 markers =
     network: tests que usan red/API real (saltan por defecto)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+pytest>=8
+pytest-asyncio>=0.23
+websockets>=12
+pytest-cov
+flake8
+mypy
+codecov


### PR DESCRIPTION
## Summary
- add dev requirements for pytest-asyncio and websockets
- enable pytest asyncio auto mode
- install dev requirements in CI workflow and update actions versions

## Testing
- `pytest -q --cov=trading_bot`


------
https://chatgpt.com/codex/tasks/task_e_68ad7e61fafc8333989d3db69bdaba35