### PR TITLE
Fix CI workflow for non-installable repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          pip install -e .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
-      - name: Run tests with coverage
+      - name: Expose repo to PYTHONPATH
+        run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Run tests
         run: pytest -q --cov=trading_bot
 
       - name: Run flake8


### PR DESCRIPTION
## Summary
- remove editable install from CI
- expose repo on `PYTHONPATH` so tests can import `trading_bot`
- keep test run with coverage

## Testing
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad91e950388333a787b2242741e217