### PR TITLE
ci: sanitize requirements before installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Sanitize requirements (remove local editable lines)
+        run: |
+          for f in requirements*.txt requirements/*.txt 2>/dev/null; do
+            [ -f "$f" ] || continue
+            sed -i '/^-e[[:space:]]\+\.$/d' "$f"
+            sed -i '/file:\/\/\/home\/runner\/work\/bot\/bot/d' "$f"
+            sed -i '/^-e[[:space:]]\+file:\/\//d' "$f"
+            sed -i '/^file:\/\//d' "$f"
+          done
+
       - name: Install dependencies
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
## Summary
- add a CI step to sanitize requirements files and strip local editable references before installing

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(hangs after tests; manual stop shows all 34 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ada244b7d0833388a89048050067e8