### PR TITLE
Add backtesting, shadow mode, and production hardening

### DIFF
--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,70 @@
+import json
+import os
+import sys
+
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import backtest
+from trading_bot import config
+
+
+def test_backtest_generates_reports(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "BACKTEST_REPORT_DIR", str(tmp_path))
+    timestamps = pd.date_range("2024-01-01", periods=20, freq="D", tz="UTC")
+    outcomes = [1 if i % 2 == 0 else -1 for i in range(20)]
+    frame = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 20,
+            "side": ["BUY"] * 20,
+            "orig_prob": [0.6 + i * 0.01 for i in range(20)],
+            "model_prob": [0.65 + i * 0.01 for i in range(20)],
+            "risk_reward": [2.0] * 20,
+            "outcome": outcomes,
+        }
+    )
+    cfg = backtest.BacktestConfig(
+        mode="walk_forward",
+        train_start="2024-01-01",
+        test_start="2024-01-05",
+        test_end="2024-01-20",
+        rolling_train_days=5,
+        rolling_test_days=5,
+        fees=0.01,
+        slippage_bps=5,
+    )
+    metrics = backtest.run_backtest(cfg, frame)
+    assert metrics["total_trades"] > 0
+    report_dirs = list(tmp_path.glob("backtest_*/kpis.json"))
+    assert report_dirs, "Expected KPI report file"
+    with report_dirs[0].open("r", encoding="utf-8") as handle:
+        stored = json.load(handle)
+    assert stored["total_trades"] == metrics["total_trades"]
+
+
+def test_iter_splits_respect_temporal_order():
+    timestamps = pd.date_range("2024-01-01", periods=10, freq="D", tz="UTC")
+    frame = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["BTCUSDT"] * 10,
+            "side": ["BUY"] * 10,
+            "orig_prob": [0.6] * 10,
+            "risk_reward": [2.0] * 10,
+            "outcome": [1] * 10,
+        }
+    )
+    cfg = backtest.BacktestConfig(
+        mode="rolling",
+        train_start="2024-01-01",
+        test_start="2024-01-05",
+        test_end="2024-01-10",
+        rolling_train_days=3,
+        rolling_test_days=2,
+    )
+    splits = list(backtest._iter_splits(frame, cfg))
+    assert splits
+    for train, test in splits:
+        assert train["timestamp"].max() < test["timestamp"].min()

--- a/tests/test_exchange_rules.py
+++ b/tests/test_exchange_rules.py
@@ -1,0 +1,32 @@
+import math
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot.exchange_rules import (
+    SymbolRules,
+    quantize_price,
+    quantize_qty,
+    validate_order,
+    ValidationError,
+)
+
+
+def test_quantize_price_and_qty():
+    rules = SymbolRules(price_tick=0.05, qty_step=0.1, min_qty=0.1)
+    assert math.isclose(quantize_price(100.07, rules.price_tick), 100.05)
+    assert math.isclose(quantize_qty(0.37, rules.qty_step), 0.3)
+
+
+def test_validate_order_checks_minimums():
+    rules = SymbolRules(price_tick=0.01, qty_step=0.1, min_qty=1.0, min_notional=10.0)
+    validate_order("BTCUSDT", "BUY", 100.0, 1.0, rules)
+    with pytest.raises(ValidationError):
+        validate_order("BTCUSDT", "BUY", 100.0, 0.5, rules)
+    with pytest.raises(ValidationError):
+        validate_order("BTCUSDT", "BUY", -1.0, 1.0, rules)
+    with pytest.raises(ValidationError):
+        validate_order("BTCUSDT", "BUY", 5.0, 1.0, rules)

--- a/tests/test_execution_state_flow.py
+++ b/tests/test_execution_state_flow.py
@@ -27,13 +27,23 @@ def test_pending_to_open_and_close(monkeypatch):
     monkeypatch.setattr(bot, "save_trades", lambda: None)
     monkeypatch.setattr(execution, "open_position", lambda *a, **k: {"id": "1", "average": 100.0})
     monkeypatch.setattr(execution, "fetch_order_status", lambda oid, sym: "filled")
+    monkeypatch.setattr(
+        execution,
+        "get_order_fill_details",
+        lambda oid, sym: {"filled": 1.0, "remaining": 0.0, "average": 100.0},
+    )
 
     tr = bot.open_new_trade(signal)
     assert tm.find_trade(trade_id="T1")["state"] == TradeState.OPEN.value
 
-    monkeypatch.setattr(execution, "close_position", lambda *a, **k: {"id": "2"})
+    monkeypatch.setattr(execution, "close_position", lambda *a, **k: {"id": "2", "average": 105.0})
     monkeypatch.setattr(execution, "fetch_order_status", lambda oid, sym: "filled")
+    monkeypatch.setattr(execution, "get_order_fill_details", lambda oid, sym: {"filled": 1.0, "remaining": 0.0, "average": 105.0})
+    monkeypatch.setattr(execution, "fetch_position_size", lambda sym: 0.0)
 
-    bot.close_existing_trade(tr, exit_price=105.0, profit=5.0, reason="TP")
+    closed, exec_price, realized = bot.close_existing_trade(tr, reason="TP")
+    assert closed is not None
+    assert exec_price == 105.0
+    assert realized == 5.0
     assert len(tm.all_closed_trades()) == 1
     assert tm.all_closed_trades()[0]["state"] == TradeState.CLOSED.value

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import idempotency
+
+
+def test_idempotency_prevents_duplicates():
+    idempotency.reset_cache(ttl_seconds=1)
+    key = idempotency.build_idempotency_key("BTCUSDT", "BUY", 100.0, 1.0, bucket_seconds=1)
+    assert idempotency.should_submit(key) is True
+    idempotency.store_result(key, {"id": "abc"})
+    assert idempotency.get_cached_result(key) == {"id": "abc"}
+    assert idempotency.should_submit(key) is False
+    assert idempotency.get_cached_result(key) == {"id": "abc"}
+    time.sleep(1.1)
+    assert idempotency.should_submit(key) is True
+    idempotency.reset_cache()

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot.latency import measure_latency
+from trading_bot.metrics import LATENCY_HISTOGRAMS
+
+
+def _histogram_count(histogram):
+    for sample in histogram.collect()[0].samples:
+        if sample.name.endswith("_count"):
+            return sample.value
+    return 0.0
+
+
+def test_measure_latency_records_histogram():
+    histogram = LATENCY_HISTOGRAMS["feature_to_prediction"]
+    before = _histogram_count(histogram)
+    with measure_latency("feature_to_prediction"):
+        time.sleep(0.01)
+    after = _histogram_count(histogram)
+    assert after == before + 1

--- a/tests/test_metrics_alerts.py
+++ b/tests/test_metrics_alerts.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import metrics
+from trading_bot import notify
+
+
+def test_maybe_alert_respects_cooldown(monkeypatch):
+    sent = []
+
+    def fake_send(message):
+        sent.append(message)
+
+    monkeypatch.setattr(notify, "send_telegram", fake_send)
+    monkeypatch.setattr(notify, "send_discord", fake_send)
+    metrics.maybe_alert(True, "alert", cooldown=1)
+    metrics.maybe_alert(True, "alert", cooldown=1)
+    assert sent.count("alert") == 2  # both telegram and discord once

--- a/tests/test_partial_fill.py
+++ b/tests/test_partial_fill.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import trading_bot.bot as bot
@@ -32,10 +34,73 @@ def test_partial_fill_is_registered(monkeypatch):
         lambda *a, **k: {"id": "1", "average": signal["entry_price"]},
     )
     monkeypatch.setattr(execution, "fetch_order_status", lambda oid, sym: "partial")
+    monkeypatch.setattr(
+        execution,
+        "get_order_fill_details",
+        lambda oid, sym: {"filled": 4.0, "remaining": 6.0, "average": signal["entry_price"]},
+    )
     monkeypatch.setattr(bot, "save_trades", lambda: None)
 
+    initial_qty = signal["quantity"]
     trade = bot.open_new_trade(signal)
     assert trade is not None
     stored = trade_manager.find_trade(symbol="AAA_USDT")
     assert stored["state"] == TradeState.PARTIALLY_FILLED.value
+    assert stored["quantity"] == 4.0
+    assert stored.get("remaining_quantity") == 6.0
+    assert stored.get("requested_quantity") == initial_qty
     assert trade_manager.count_open_trades() == 1
+
+
+def test_partial_close_retries_remaining(monkeypatch):
+    ex = MockExchange(order_status_flow="open")
+    monkeypatch.setattr(execution, "exchange", ex)
+    trade_manager.reset_state()
+
+    trade = {
+        "trade_id": "T2",
+        "symbol": "BBB_USDT",
+        "side": "BUY",
+        "quantity": 1.0,
+        "entry_price": 100.0,
+        "take_profit": 110.0,
+        "stop_loss": 95.0,
+        "prob_success": 0.7,
+        "leverage": 1,
+    }
+
+    monkeypatch.setattr(bot, "save_trades", lambda: None)
+    trade_manager.add_trade(trade)
+    trade_manager.set_trade_state(trade["trade_id"], TradeState.OPEN)
+
+    close_calls: list[float] = []
+
+    def _close_position(symbol, side, amount, order_type="market"):
+        close_calls.append(amount)
+        order_id = str(len(close_calls))
+        return {"id": order_id, "average": 100.0}
+
+    status_map = {"1": ["partial", "filled"], "2": ["filled"]}
+
+    def _fetch_order_status(order_id, symbol):
+        seq = status_map.get(order_id, ["filled"])
+        if seq:
+            return seq.pop(0)
+        return "filled"
+
+    def _fill_details(order_id, symbol):
+        if order_id == "1":
+            return {"filled": 0.5, "remaining": 0.5, "average": 100.0}
+        return {"filled": 1.0, "remaining": 0.0, "average": 100.0}
+
+    monkeypatch.setattr(execution, "close_position", _close_position)
+    monkeypatch.setattr(execution, "fetch_order_status", _fetch_order_status)
+    monkeypatch.setattr(execution, "get_order_fill_details", _fill_details)
+    monkeypatch.setattr(execution, "fetch_position_size", lambda symbol: 0.0)
+
+    closed, exec_price, realized = bot.close_existing_trade(trade, reason="SL")
+    assert closed is not None
+    assert exec_price == pytest.approx(100.0)
+    assert realized == pytest.approx(0.0)
+    assert close_calls and close_calls[0] == pytest.approx(1.0)
+    assert len(close_calls) >= 2

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot.shadow import (
+    ShadowConfig,
+    configure,
+    record_shadow_signal,
+    finalize_shadow_trade,
+)
+
+
+def test_shadow_records_to_disk(tmp_path):
+    cfg = ShadowConfig(enabled=True, record_to=tmp_path)
+    configure(cfg)
+    record_shadow_signal("BTCUSDT", "heuristic", {"prob_success": 0.6})
+    finalize_shadow_trade("trade-1", {"pnl": 1.5})
+    signals_path = tmp_path / "signals.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    assert signals_path.exists()
+    assert results_path.exists()
+    assert "BTCUSDT" in signals_path.read_text(encoding="utf-8")
+    assert "trade-1" in results_path.read_text(encoding="utf-8")

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import shutdown
+
+
+def test_shutdown_callbacks_executed():
+    shutdown.reset_for_tests()
+    called = []
+
+    def _callback():
+        called.append(True)
+
+    shutdown.register_callback(_callback)
+    shutdown.request_shutdown()
+    assert shutdown.shutdown_requested() is True
+    shutdown.execute_callbacks()
+    assert called == [True]
+    shutdown.reset_for_tests()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,9 +3,10 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
-def test_open_close_trade_smoke():
+def test_open_close_trade_smoke(monkeypatch):
     import trading_bot.bot as bot
     import trading_bot.trade_manager as tm
+    from trading_bot import execution
 
     signal = {
         "symbol": "BTC_USDT",
@@ -16,11 +17,31 @@ def test_open_close_trade_smoke():
         "stop_loss": 90.0,
         "leverage": 5,
     }
+    monkeypatch.setattr(bot, "save_trades", lambda: None)
+    monkeypatch.setattr(execution, "open_position", lambda *a, **k: {"id": "1", "average": 100.0})
+    monkeypatch.setattr(execution, "fetch_order_status", lambda oid, sym: "filled")
+    monkeypatch.setattr(
+        execution,
+        "get_order_fill_details",
+        lambda oid, sym: {"filled": 1.0, "remaining": 0.0, "average": 100.0},
+    )
     trade = bot.open_new_trade(signal)
     assert trade is not None
     assert tm.count_open_trades() == 1
 
-    bot.close_existing_trade(trade, exit_price=105.0, profit=5.0, reason="TP")
+    monkeypatch.setattr(execution, "close_position", lambda *a, **k: {"id": "2", "average": 105.0})
+    monkeypatch.setattr(execution, "fetch_order_status", lambda oid, sym: "filled")
+    monkeypatch.setattr(
+        execution,
+        "get_order_fill_details",
+        lambda oid, sym: {"filled": 1.0, "remaining": 0.0, "average": 105.0},
+    )
+    monkeypatch.setattr(execution, "fetch_position_size", lambda sym: 0.0)
+
+    closed, exec_price, realized = bot.close_existing_trade(trade, reason="TP")
+    assert closed is not None
+    assert exec_price is not None
+    assert realized is not None
     assert tm.count_open_trades() == 0
     assert len(tm.all_closed_trades()) == 1
 

--- a/tests/test_strategy_probabilities.py
+++ b/tests/test_strategy_probabilities.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from trading_bot import config, strategy
+
+
+@pytest.fixture(autouse=True)
+def _reset_override():
+    strategy.set_model_weight_override(None)
+    yield
+    strategy.set_model_weight_override(None)
+
+
+def test_probability_threshold_respects_margin(monkeypatch):
+    monkeypatch.setattr(config, "MIN_PROB_SUCCESS", 0.4, raising=False)
+    monkeypatch.setattr(config, "PROBABILITY_MARGIN", 0.1, raising=False)
+    monkeypatch.setattr(config, "FEE_EST", 0.2, raising=False)
+
+    threshold = strategy.probability_threshold(1.0)
+    breakeven = 0.2 / (1.0 + 0.2)
+    assert pytest.approx(threshold, rel=1e-6) == max(0.4, breakeven + 0.1)
+
+
+def test_probability_threshold_caps(monkeypatch):
+    monkeypatch.setattr(config, "MIN_PROB_SUCCESS", 0.99, raising=False)
+    monkeypatch.setattr(config, "PROBABILITY_MARGIN", 0.1, raising=False)
+    monkeypatch.setattr(config, "FEE_EST", 0.5, raising=False)
+
+    threshold = strategy.probability_threshold(0.1)
+    assert threshold <= 0.995
+
+
+def test_model_weight_override():
+    base_weight = strategy.get_model_weight()
+    strategy.set_model_weight_override(0.2)
+    assert strategy.get_model_weight() == pytest.approx(0.2)
+    strategy.set_model_weight_override(None)
+    assert strategy.get_model_weight() == pytest.approx(base_weight)

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -1,124 +1,221 @@
-import logging
+"""Walk-forward backtest utilities for the trading bot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Literal
+
+import numpy as np
 import pandas as pd
-from typing import List
-from . import data, strategy
 
-logger = logging.getLogger(__name__)
+from . import config, strategy
 
 
-def run_backtest(symbols: List[str], interval: str = "Min15", limit: int = 500) -> pd.DataFrame:
-    """Run a simplified historical backtest for several symbols.
+@dataclass
+class BacktestConfig:
+    mode: Literal["walk_forward", "rolling"] = "walk_forward"
+    train_start: datetime | str | None = None
+    test_start: datetime | str | None = None
+    test_end: datetime | str | None = None
+    rolling_train_days: int = 30
+    rolling_test_days: int = 7
+    fees: float = config.FEE_EST
+    slippage_bps: float = 0.0
+    latency_ms: int = 0
+    model_weight: float = config.MODEL_WEIGHT
+    min_prob_success: float = config.MIN_PROB_SUCCESS
+    rr_floor: float = config.MIN_RISK_REWARD
 
-    Parameters
-    ----------
-    symbols : List[str]
-        Trading pairs in the format ``BASE_QUOTE`` (e.g. ``"BTC_USDT"``).
-    interval : str, optional
-        Candle interval used by :func:`data.get_market_data`. Defaults to
-        ``"Min15"``.
-    limit : int, optional
-        Number of candles to request for each symbol. Defaults to ``500``.
 
-    Algorithm
-    ---------
-    For each symbol the function downloads historical OHLCV data and iterates
-    over the candles starting at index 150. At each step a window of previous
-    prices is passed to :func:`strategy.decidir_entrada` in order to obtain a
-    hypothetical trade signal. The trade is simulated for up to ten candles
-    applying the provided take profit or stop loss. The equity curve is tracked
-    to calculate the win rate, cumulative profit and the maximum drawdown.
+@dataclass
+class TradeResult:
+    timestamp: pd.Timestamp
+    symbol: str
+    side: str
+    probability: float
+    risk_reward: float
+    outcome: float
+    profit: float
 
-    Returns
-    -------
-    pandas.DataFrame
-        A dataframe with one row per symbol containing the columns
-        ``symbol``, ``trades``, ``profit``, ``win_rate`` and ``max_drawdown``.
-    """
-    results = []
-    for sym in symbols:
-        info = data.get_market_data(sym, interval=interval, limit=limit)
-        if not isinstance(info, dict) or not all(k in info for k in ("close", "high", "low", "vol")):
-            logger.error("Invalid data for %s", sym)
+
+def _parse_timestamp(value: datetime | str | None, fallback: pd.Timestamp) -> pd.Timestamp:
+    if value is None:
+        return fallback
+    if isinstance(value, datetime):
+        ts = pd.Timestamp(value)
+    else:
+        ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.tz_localize(fallback.tz)
+    return ts.tz_convert(fallback.tz) if fallback.tz is not None else ts
+
+
+def _iter_splits(frame: pd.DataFrame, cfg: BacktestConfig):
+    timestamps = pd.to_datetime(frame["timestamp"], utc=True)
+    frame = frame.assign(timestamp=timestamps).sort_values("timestamp")
+    overall_start = timestamps.min()
+    test_start = _parse_timestamp(cfg.test_start, overall_start)
+    test_end = _parse_timestamp(cfg.test_end, timestamps.max())
+    pointer = test_start
+    while pointer < test_end:
+        if cfg.mode == "rolling":
+            train_start = pointer - timedelta(days=cfg.rolling_train_days)
+        else:
+            train_start = _parse_timestamp(cfg.train_start, overall_start)
+        train_mask = (timestamps >= train_start) & (timestamps < pointer)
+        test_end_split = min(pointer + timedelta(days=cfg.rolling_test_days), test_end)
+        test_mask = (timestamps >= pointer) & (timestamps < test_end_split)
+        if train_mask.sum() == 0 or test_mask.sum() == 0:
+            pointer = test_end_split
             continue
-        closes = [float(x) for x in info["close"]]
-        highs = [float(x) for x in info["high"]]
-        lows = [float(x) for x in info["low"]]
-        vols = [float(x) for x in info["vol"]]
+        yield frame.loc[train_mask], frame.loc[test_mask]
+        pointer = test_end_split
 
-        profit_total = 0.0
-        trades = 0
-        wins = 0
-        equity = 0.0
-        peak = 0.0
-        dd = 0.0
-        for i in range(150, len(closes) - 10):
-            window = {
-                "close": closes[:i],
-                "high": highs[:i],
-                "low": lows[:i],
-                "vol": vols[:i],
-            }
-            sig = strategy.decidir_entrada(sym, info=window)
-            if not sig:
+
+def blend_probability(orig: float, model: float | None, weight: float) -> float:
+    return strategy.blend_probabilities(orig, model, weight)
+
+
+def simulate_decision(row: pd.Series, cfg: BacktestConfig) -> dict | None:
+    risk_reward = float(row.get("risk_reward", 0.0))
+    if risk_reward < cfg.rr_floor:
+        return None
+    orig_prob = float(row.get("orig_prob", 0.0))
+    model_prob = row.get("model_prob")
+    model_prob_f = float(model_prob) if model_prob is not None else None
+    blended = blend_probability(orig_prob, model_prob_f, cfg.model_weight)
+    threshold = max(cfg.min_prob_success, strategy.probability_threshold(risk_reward))
+    if blended < threshold:
+        return None
+    return {
+        "symbol": row.get("symbol", "UNKNOWN"),
+        "side": row.get("side", "BUY"),
+        "probability": blended,
+        "risk_reward": risk_reward,
+        "timestamp": row.get("timestamp"),
+    }
+
+
+def apply_trade(signal: dict, row: pd.Series, cfg: BacktestConfig) -> TradeResult:
+    outcome = float(row.get("outcome", 0.0))
+    risk_reward = float(signal["risk_reward"])
+    probability = float(signal["probability"])
+    slippage = cfg.slippage_bps / 10_000.0
+    trade_cost = cfg.fees + slippage
+    if outcome > 0:
+        profit = risk_reward - trade_cost
+    else:
+        profit = -1.0 - trade_cost
+    timestamp_value = signal["timestamp"]
+    ts = pd.Timestamp(timestamp_value)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return TradeResult(
+        timestamp=ts,
+        symbol=str(signal["symbol"]),
+        side=str(signal["side"]),
+        probability=probability,
+        risk_reward=risk_reward,
+        outcome=outcome,
+        profit=profit,
+    )
+
+
+def compute_kpis(trades: Iterable[TradeResult]) -> dict:
+    trades_list = list(trades)
+    if not trades_list:
+        return {
+            "total_trades": 0,
+            "win_rate": 0.0,
+            "expectancy": 0.0,
+            "profit_factor": 0.0,
+            "cagr": 0.0,
+            "max_drawdown": 0.0,
+            "sharpe": 0.0,
+        }
+    profits = np.array([t.profit for t in trades_list])
+    wins = profits > 0
+    win_rate = float(wins.mean())
+    expectancy = float(profits.mean())
+    gains = profits[profits > 0].sum()
+    losses = -profits[profits < 0].sum()
+    profit_factor = float(gains / losses) if losses > 0 else float("inf" if gains > 0 else 0.0)
+    equity = profits.cumsum()
+    peaks = np.maximum.accumulate(equity)
+    drawdowns = peaks - equity
+    max_drawdown = float(drawdowns.max()) if len(drawdowns) else 0.0
+    first_ts = trades_list[0].timestamp
+    last_ts = trades_list[-1].timestamp
+    years = max((last_ts - first_ts).days / 365.25, 1e-6)
+    cagr = float(((1 + profits.sum()) ** (1 / years)) - 1)
+    std = profits.std(ddof=1) if len(profits) > 1 else 0.0
+    sharpe = float(expectancy / std) if std else 0.0
+    return {
+        "total_trades": len(trades_list),
+        "win_rate": win_rate,
+        "expectancy": expectancy,
+        "profit_factor": profit_factor,
+        "cagr": cagr,
+        "max_drawdown": max_drawdown,
+        "sharpe": sharpe,
+    }
+
+
+def run_backtest(cfg: BacktestConfig, data: pd.DataFrame) -> dict:
+    results: list[TradeResult] = []
+    for _, test_chunk in _iter_splits(data, cfg):
+        for _, row in test_chunk.iterrows():
+            signal = simulate_decision(row, cfg)
+            if not signal:
                 continue
-            entry = closes[i]
-            side = sig["side"]
-            sl = sig["stop_loss"]
-            tp = sig["take_profit"]
-            exit_price = entry
-            for j in range(i + 1, min(i + 10, len(closes))):
-                h = highs[j]
-                l = lows[j]
-                if side == "BUY":
-                    if l <= sl:
-                        exit_price = sl
-                        break
-                    if h >= tp:
-                        exit_price = tp
-                        break
-                else:
-                    if h >= sl:
-                        exit_price = sl
-                        break
-                    if l <= tp:
-                        exit_price = tp
-                        break
-                exit_price = closes[j]
-            if side == "BUY":
-                profit = exit_price - entry
-            else:
-                profit = entry - exit_price
-            profit_total += profit
-            trades += 1
-            if profit > 0:
-                wins += 1
-            equity += profit
-            if equity > peak:
-                peak = equity
-            dd = max(dd, peak - equity)
-        win_rate = wins / trades if trades else 0
-        results.append(
-            {
-                "symbol": sym,
-                "trades": trades,
-                "profit": profit_total,
-                "win_rate": win_rate,
-                "max_drawdown": dd,
-            }
-        )
-    return pd.DataFrame(results)
+            trade = apply_trade(signal, row, cfg)
+            results.append(trade)
+    kpis = compute_kpis(results)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    report_dir = Path(config.BACKTEST_REPORT_DIR) / f"backtest_{timestamp}"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    trades_frame = pd.DataFrame([t.__dict__ for t in results])
+    trades_frame.to_csv(report_dir / "trades.csv", index=False)
+    with (report_dir / "kpis.json").open("w", encoding="utf-8") as handle:
+        json.dump(kpis, handle, indent=2, default=str)
+    with (report_dir / "config.json").open("w", encoding="utf-8") as handle:
+        json.dump(cfg.__dict__, handle, indent=2, default=str)
+    return kpis
+
+
+def _load_config(path: Path) -> BacktestConfig:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("PyYAML is required to load backtest configs") from exc
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+    return BacktestConfig(**payload)
+
+
+def _load_dataset(csv_path: Path) -> pd.DataFrame:
+    frame = pd.read_csv(csv_path)
+    if "timestamp" not in frame.columns:
+        raise ValueError("Dataset must contain a 'timestamp' column")
+    return frame
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a walk-forward backtest")
+    parser.add_argument("--config", type=Path, required=True, help="Path to a YAML config file")
+    parser.add_argument("--data", type=Path, required=True, help="CSV dataset with features")
+    args = parser.parse_args()
+    cfg = _load_config(args.config)
+    data = _load_dataset(args.data)
+    kpis = run_backtest(cfg, data)
+    print(json.dumps(kpis, indent=2))
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Run a simple backtest")
-    parser.add_argument("symbols", nargs="*", help="Symbols to backtest, e.g. BTC_USDT ETH_USDT")
-    parser.add_argument("--interval", default="Min15", help="Candle interval")
-    parser.add_argument("--limit", type=int, default=500, help="Number of candles")
-    args = parser.parse_args()
-
-    symbols = args.symbols or ["BTC_USDT"]
-    df = run_backtest(symbols, interval=args.interval, limit=args.limit)
-    print(df.to_string(index=False))
-
+    main()

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -5,8 +5,11 @@ env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env"
 load_dotenv(env_path)
 
 import logging
+import os
 import time
-from threading import Thread
+from collections import deque
+from statistics import mean
+from threading import Thread, RLock
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
@@ -22,6 +25,8 @@ from . import (
     optimizer,
     permissions,
     trade_manager,
+    shadow,
+    shutdown,
 )
 from .trade_manager import (
     add_trade,
@@ -36,7 +41,12 @@ from .trade_manager import (
     set_trade_state,
 )
 from .state_machine import TradeState
-from .metrics import start_metrics_server, update_trade_metrics
+from .metrics import (
+    start_metrics_server,
+    update_trade_metrics,
+    record_model_performance,
+    maybe_alert,
+)
 from .monitor import monitor_system
 from .utils import normalize_symbol
 
@@ -51,10 +61,162 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+class ModelPerformanceMonitor:
+    """Track predictive performance and adjust model weight when degraded."""
+
+    def __init__(
+        self,
+        window: int,
+        min_samples: int,
+        min_win_rate: float,
+        max_drift: float,
+    ) -> None:
+        self.samples: deque[tuple[float, int]] = deque(maxlen=window)
+        self.min_samples = min_samples
+        self.min_win_rate = min_win_rate
+        self.max_drift = max_drift
+        self._lock = RLock()
+        self._degraded = False
+
+    def reset(self) -> None:
+        with self._lock:
+            self.samples.clear()
+            self._degraded = False
+
+    def record_trade(self, trade: dict | None) -> None:
+        if not trade:
+            return
+        prob = trade.get("model_prob")
+        if prob is None:
+            return
+        outcome = 1 if float(trade.get("profit", 0.0)) > 0 else 0
+        with self._lock:
+            self.samples.append((float(prob), outcome))
+            self._evaluate_locked()
+
+    def _evaluate_locked(self) -> None:
+        if len(self.samples) < max(self.min_samples, 1):
+            return
+        avg_prob = mean(p for p, _ in self.samples)
+        win_rate = mean(outcome for _, outcome in self.samples)
+        drift = abs(avg_prob - win_rate)
+        record_model_performance(win_rate, avg_prob, drift)
+
+        current_weight = strategy.get_model_weight()
+        if (
+            (win_rate < self.min_win_rate or drift > self.max_drift)
+            and current_weight > config.MODEL_WEIGHT_FLOOR
+        ):
+            new_weight = max(
+                config.MODEL_WEIGHT * config.MODEL_WEIGHT_DEGRADATION,
+                config.MODEL_WEIGHT_FLOOR,
+            )
+            strategy.set_model_weight_override(new_weight)
+            self._degraded = True
+            logger.warning(
+                "Model weight degraded to %.2f due to drift (win_rate=%.2f avg_prob=%.2f drift=%.2f)",
+                new_weight,
+                win_rate,
+                avg_prob,
+                drift,
+            )
+            self.samples.clear()
+            return
+
+        if self._degraded and win_rate >= self.min_win_rate and drift <= self.max_drift:
+            strategy.set_model_weight_override(None)
+            self._degraded = False
+            logger.info(
+                "Model performance recovered (win_rate=%.2f avg_prob=%.2f); restoring weight %.2f",
+                win_rate,
+                avg_prob,
+                config.MODEL_WEIGHT,
+            )
+            self.samples.clear()
+
+
+_model_lock = RLock()
+_cached_model = None
+_cached_model_mtime: float | None = None
+_model_missing_logged = False
+
+
+def _set_cached_model(model) -> None:
+    global _cached_model
+    with _model_lock:
+        _cached_model = model
+
+
+def _model_manifest_timestamp(path: str) -> float | None:
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def maybe_reload_model(force: bool = False) -> None:
+    """Reload the predictive model if the file changed."""
+
+    global _cached_model_mtime, _model_missing_logged
+    model_path = config.MODEL_PATH
+    mtime = _model_manifest_timestamp(model_path)
+    if mtime is None:
+        if force or (_cached_model is not None):
+            logger.warning("Modelo no disponible en %s", model_path)
+        _set_cached_model(None)
+        _cached_model_mtime = None
+        _model_missing_logged = True
+        return
+
+    if not force and _cached_model_mtime is not None and mtime <= _cached_model_mtime:
+        return
+
+    model = optimizer.load_model(model_path)
+    if model is None:
+        if not _model_missing_logged:
+            logger.warning(
+                "No se encontró el modelo histórico en %s; las señales se generarán sin ajuste.",
+                model_path,
+            )
+            _model_missing_logged = True
+        _set_cached_model(None)
+        _cached_model_mtime = None
+        return
+
+    _set_cached_model(model)
+    _cached_model_mtime = mtime
+    _model_missing_logged = False
+    strategy.set_model_weight_override(None)
+    MODEL_MONITOR.reset()
+    logger.info("Modelo predictivo recargado desde %s", model_path)
+
+
+def current_model():
+    with _model_lock:
+        return _cached_model
+
+
+MODEL_MONITOR = ModelPerformanceMonitor(
+    config.MODEL_PERFORMANCE_WINDOW,
+    config.MODEL_MIN_SAMPLES_FOR_MONITOR,
+    config.MODEL_MIN_WIN_RATE,
+    config.MODEL_MAX_CALIBRATION_DRIFT,
+)
+
 def open_new_trade(signal: dict):
     """Open a position and track its state via ``trade_manager``."""
     symbol = signal["symbol"]
     raw = normalize_symbol(symbol).replace("_", "")
+
+    if config.SHADOW_MODE:
+        hybrid_payload = dict(signal)
+        heuristic_payload = dict(signal)
+        if "orig_prob" in heuristic_payload:
+            heuristic_payload["prob_success"] = heuristic_payload["orig_prob"]
+        shadow.record_shadow_signal(symbol, "heuristic", heuristic_payload)
+        shadow.record_shadow_signal(symbol, "hybrid", hybrid_payload)
+        return None
 
     # Register trade in pending state first
     trade = add_trade(signal)
@@ -90,6 +252,22 @@ def open_new_trade(signal: dict):
             set_trade_state(trade["trade_id"], TradeState.PARTIALLY_FILLED)
         # else: remain in PENDING
 
+        if status in {"filled", "partial"}:
+            details = execution.get_order_fill_details(order_id, symbol)
+            if details:
+                updates: dict[str, float] = {}
+                filled_qty = details.get("filled")
+                if filled_qty is not None and filled_qty > 0:
+                    updates["quantity"] = filled_qty
+                remaining_qty = details.get("remaining")
+                if remaining_qty is not None:
+                    updates["remaining_quantity"] = max(remaining_qty, 0.0)
+                avg_exec = details.get("average")
+                if avg_exec:
+                    updates.setdefault("entry_price", avg_exec)
+                if updates:
+                    update_trade(trade["trade_id"], **updates)
+
         save_trades()
         return find_trade(trade_id=trade["trade_id"])
 
@@ -105,32 +283,93 @@ def open_new_trade(signal: dict):
     return None
 
 
-def close_existing_trade(trade: dict, exit_price: float, profit: float, reason: str) -> None:
-    """Close a trade enforcing state transitions."""
+def close_existing_trade(
+    trade: dict, reason: str
+) -> tuple[dict | None, float | None, float | None]:
+    """Close a trade enforcing state transitions and return results."""
+
     trade_id = trade.get("trade_id")
     symbol = trade.get("symbol")
-    qty = trade.get("quantity", 0)
+    qty = float(trade.get("quantity", 0.0))
     close_side = "close_short" if trade.get("side") == "SELL" else "close_long"
 
     set_trade_state(trade_id, TradeState.CLOSING)
-    order = execution.close_position(symbol, close_side, qty, order_type="market")
-    status = execution.fetch_order_status(order.get("id"), symbol)
-
-    if status in ("filled", "partial"):
-        close_trade(
-            trade_id=trade_id,
-            reason=reason,
-            exit_price=exit_price,
-            profit=profit,
-        )
-    else:
+    try:
+        order = execution.close_position(symbol, close_side, qty, order_type="market")
+    except execution.OrderSubmitError:
+        logger.error("Order submission failed when closing %s", symbol)
         set_trade_state(trade_id, TradeState.FAILED)
+        save_trades()
+        return None, None, None
 
+    order_id = order.get("id")
+    exec_price = float(order.get("average") or order.get("price") or trade.get("entry_price", 0.0))
+
+    if order_id:
+        attempts = max(1, config.API_RETRY_ATTEMPTS)
+        for attempt in range(attempts):
+            status = execution.fetch_order_status(order_id, symbol)
+            if status == "filled":
+                break
+            if status == "partial":
+                details = execution.get_order_fill_details(order_id, symbol)
+                remaining_qty = 0.0
+                if details:
+                    remaining_qty = max(details.get("remaining", 0.0) or 0.0, 0.0)
+                    if details.get("average"):
+                        exec_price = float(details["average"])
+                if remaining_qty <= config.CLOSE_REMAINING_TOLERANCE:
+                    break
+                logger.warning(
+                    "Partial close for %s (remaining %.6f); reattempting", symbol, remaining_qty
+                )
+                try:
+                    order = execution.close_position(
+                        symbol, close_side, remaining_qty, order_type="market"
+                    )
+                    order_id = order.get("id", order_id)
+                    if order.get("average"):
+                        exec_price = float(order.get("average"))
+                except execution.OrderSubmitError:
+                    logger.error("Failed to close remaining %.6f for %s", remaining_qty, symbol)
+                    break
+            else:
+                break
+            time.sleep(0.5 * (attempt + 1))
+
+    remaining = execution.fetch_position_size(symbol)
+    if remaining > config.CLOSE_REMAINING_TOLERANCE:
+        logger.warning(
+            "Remanente %.6f detectado tras cierre de %s; trade marcado como parcial",
+            remaining,
+            symbol,
+        )
+        update_trade(trade_id, quantity=remaining)
+        set_trade_state(trade_id, TradeState.PARTIALLY_FILLED)
+        save_trades()
+        return None, exec_price, None
+
+    entry_price = float(trade.get("entry_price", exec_price))
+    if trade.get("side") == "BUY":
+        realized = (exec_price - entry_price) * qty
+    else:
+        realized = (entry_price - exec_price) * qty
+
+    closed = close_trade(
+        trade_id=trade_id,
+        reason=reason,
+        exit_price=exec_price,
+        profit=realized,
+    )
+    MODEL_MONITOR.record_trade(closed)
     save_trades()
+    return closed, exec_price, realized
 
 
 def run_one_iteration_open(model=None):
     """Execute a single iteration of the opening logic."""
+    if model is None:
+        model = current_model()
     execution.cleanup_old_orders()
     if count_open_trades() >= config.MAX_OPEN_TRADES:
         return
@@ -239,14 +478,17 @@ def run():
 
     strategy.start_liquidity()
 
-    model = optimizer.load_model(config.MODEL_PATH)
-    if model is None:
-        logger.warning(
-            "No se encontró el modelo histórico en %s; las señales se generarán sin ajuste.",
-            config.MODEL_PATH,
-        )
+    shutdown.install_signal_handlers()
+    shutdown.register_callback(save_trades)
+    shutdown.register_callback(execution.cancel_all_orders)
+
+    maybe_reload_model(force=True)
     daily_profit = 0.0
     trading_active = True
+    current_day = datetime.now(timezone.utc).date()
+    loss_limit = -abs(config.DAILY_RISK_LIMIT)
+    standby_notified = False
+    shutdown_handled = False
 
     # Initial metric update
     update_trade_metrics(count_open_trades(), len(trade_manager.all_closed_trades()))
@@ -257,14 +499,34 @@ def run():
         try:
 
             execution.cleanup_old_orders()
+
+            maybe_reload_model()
+            model = current_model()
+
+            if shutdown.shutdown_requested() and not shutdown_handled:
+                logger.info("Shutdown requested; stopping trading loop")
+                trading_active = False
+                shutdown_handled = True
+                shutdown.execute_callbacks()
+                break
+
+            now = datetime.now(timezone.utc)
+            if now.date() != current_day:
+                current_day = now.date()
+                daily_profit = 0.0
+                trading_active = True
+                standby_notified = False
+                logger.info("New trading day detected; counters reset")
+
             # Detener nuevas entradas cuando la pérdida diaria alcanza el límite
             # Se acepta que DAILY_RISK_LIMIT pueda definirse como valor negativo
             # (por ejemplo -50.0) o positivo (50.0). Siempre se compara contra
             # el valor negativo correspondiente.
-            loss_limit = -abs(config.DAILY_RISK_LIMIT)
             if daily_profit <= loss_limit and trading_active:
                 trading_active = False
+                standby_notified = False
                 logger.error("Daily loss limit reached %.2f", daily_profit)
+                maybe_alert(True, f"Daily loss limit reached {daily_profit:.2f} USDT")
 
 
             # ABRIR NUEVAS OPERACIONES (solo si hay hueco y permitido)
@@ -360,25 +622,17 @@ def run():
                     reason = "MAX_DURATION"
 
                 if close:
-                    try:
-
-                        order = execution.close_position(op["symbol"], side_close, op["quantity"])
-                        if not isinstance(order, dict):
-                            logger.warning("Close response unexpected for %s: %s", op["symbol"], order)
-                            continue
-                        order_id = order.get("id")
-                        if not execution.check_order_filled(order_id, op["symbol"]):
-                            logger.warning("Close order not filled for %s", op["symbol"])
-                            execution.cancel_order(order_id, op["symbol"])
-                            continue
-                        exec_price = float(order.get("average") or price)
-                    except execution.OrderSubmitError:
-                        logger.error("Failed closing %s", op["symbol"])
-                        continue
                     expected = op["take_profit"] if (
                         (op["side"] == "BUY" and price >= op["take_profit"]) or
                         (op["side"] == "SELL" and price <= op["take_profit"])
                     ) else op["stop_loss"]
+                    close_label = reason or ("TP" if profit >= 0 else "SL")
+                    closed, exec_price, realized = close_existing_trade(
+                        op,
+                        close_label,
+                    )
+                    if not closed or exec_price is None or realized is None:
+                        continue
                     slippage = exec_price - expected
                     logger.info(
                         "Closed %s at %.4f (target %.4f) slippage %.4f",
@@ -386,18 +640,12 @@ def run():
                     )
                     if abs(slippage) > config.MAX_SLIPPAGE:
                         logger.warning("High slippage detected on %s: %.4f", op["symbol"], slippage)
-                    close_existing_trade(
-                        op,
-                        exec_price,
-                        profit,
-                        reason or ("TP" if profit >= 0 else "SL"),
-                    )
-                    daily_profit += profit
+                    daily_profit += realized
 
-                    outcome = reason or ("TP" if profit >= 0 else "SL")
+                    outcome = close_label
                     note = (
                         f"Closed {op['symbol']} {outcome} "
-                        f"PnL {profit:.2f} Slippage {slippage:.4f}"
+                        f"PnL {realized:.2f} Slippage {slippage:.4f}"
                     )
                     notify.send_telegram(note)
                     notify.send_discord(note)
@@ -405,10 +653,10 @@ def run():
             save_trades()  # Guarda el estado periódicamente
             update_trade_metrics(count_open_trades(), len(trade_manager.all_closed_trades()))
 
-            if not trading_active and count_open_trades() == 0:
+            if not trading_active and count_open_trades() == 0 and not standby_notified:
                 logger.info("All positions closed after reaching daily limit")
                 save_trades()
-                break
+                standby_notified = True
             time.sleep(60)
         except KeyboardInterrupt:
 
@@ -422,6 +670,8 @@ def run():
         except Exception as exc:
             logger.error("Loop error: %s", exc)
             time.sleep(10)
+
+    logger.info("Trading loop exited")
 
 if __name__ == "__main__":
     run()

--- a/trading_bot/exchange_rules.py
+++ b/trading_bot/exchange_rules.py
@@ -1,0 +1,99 @@
+"""Helpers to validate orders against exchange trading rules."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+class ValidationError(Exception):
+    """Raised when an order violates exchange constraints."""
+
+
+@dataclass
+class SymbolRules:
+    price_tick: float
+    qty_step: float
+    min_qty: float
+    min_notional: float | None = None
+    max_leverage: float | None = None
+
+
+_CACHE: Dict[str, tuple[SymbolRules, float]] = {}
+_CACHE_LOCK = threading.RLock()
+_CACHE_TTL = 300.0
+
+
+def _fetch_rules_from_exchange(symbol: str):
+    try:
+        from . import execution  # Local import to avoid circular dependency
+
+        exchange = execution.exchange
+    except Exception:
+        exchange = None
+    if exchange is None:
+        return None
+    market_symbol = symbol.replace("_", "/") + ":USDT"
+    market = exchange.markets.get(market_symbol) if hasattr(exchange, "markets") else None
+    if not market:
+        return None
+    precision = market.get("precision", {})
+    limits = market.get("limits", {})
+    price_tick = float(precision.get("price", 0.0) or market.get("tickSize", 0.0) or 0.01)
+    qty_step = float(precision.get("amount", 0.0) or market.get("stepSize", 0.0) or 0.001)
+    min_qty = float(limits.get("amount", {}).get("min", 0.0) or market.get("minQty", 0.0) or qty_step)
+    min_notional = limits.get("cost", {}).get("min") or market.get("minNotional")
+    max_leverage = market.get("maxLeverage")
+    return SymbolRules(price_tick=price_tick, qty_step=qty_step, min_qty=min_qty, min_notional=min_notional, max_leverage=max_leverage)
+
+
+def get_symbol_rules(symbol: str, *, fallback: Optional[SymbolRules] = None) -> SymbolRules:
+    """Return :class:`SymbolRules` for ``symbol`` caching results for ``CACHE_TTL`` seconds."""
+
+    now = time.time()
+    with _CACHE_LOCK:
+        if symbol in _CACHE:
+            rules, ts = _CACHE[symbol]
+            if now - ts <= _CACHE_TTL:
+                return rules
+        rules = _fetch_rules_from_exchange(symbol) or fallback or SymbolRules(0.01, 0.001, 0.001)
+        _CACHE[symbol] = (rules, now)
+        return rules
+
+
+def quantize_price(price: float, tick: float) -> float:
+    if tick <= 0:
+        return price
+    return math.floor(price / tick) * tick
+
+
+def quantize_qty(qty: float, step: float) -> float:
+    if step <= 0:
+        return qty
+    return math.floor(qty / step) * step
+
+
+def validate_order(symbol: str, side: str, price: float | None, qty: float, rules: SymbolRules) -> None:
+    if qty <= 0:
+        raise ValidationError("quantity must be positive")
+    if rules.min_qty and qty < rules.min_qty:
+        raise ValidationError(f"quantity {qty} below minimum {rules.min_qty}")
+    if price is not None and price <= 0:
+        raise ValidationError("price must be positive")
+    if rules.min_notional and price is not None:
+        notional = price * qty
+        if notional < rules.min_notional:
+            raise ValidationError(f"notional {notional:.8f} below minimum {rules.min_notional}")
+
+
+__all__ = [
+    "ValidationError",
+    "SymbolRules",
+    "get_symbol_rules",
+    "quantize_price",
+    "quantize_qty",
+    "validate_order",
+]

--- a/trading_bot/idempotency.py
+++ b/trading_bot/idempotency.py
@@ -1,0 +1,99 @@
+"""Utilities to avoid duplicated order submissions."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class _CacheEntry:
+    created_at: float
+    payload: Any
+
+
+class IdempotencyCache:
+    """Simple in-memory cache with TTL semantics for idempotency keys."""
+
+    def __init__(self, ttl_seconds: float = 60.0, max_size: int = 512) -> None:
+        self.ttl_seconds = ttl_seconds
+        self.max_size = max_size
+        self._items: Dict[str, _CacheEntry] = {}
+        self._lock = threading.RLock()
+
+    def _purge_expired(self) -> None:
+        now = time.time()
+        expired = [key for key, entry in self._items.items() if now - entry.created_at > self.ttl_seconds]
+        for key in expired:
+            self._items.pop(key, None)
+        # Keep dictionary bounded even if TTL not triggered yet
+        if len(self._items) > self.max_size:
+            for key in list(self._items.keys())[: len(self._items) - self.max_size]:
+                self._items.pop(key, None)
+
+    def add(self, key: str, payload: Any) -> None:
+        with self._lock:
+            self._purge_expired()
+            self._items[key] = _CacheEntry(time.time(), payload)
+
+    def get(self, key: str) -> Optional[Any]:
+        with self._lock:
+            self._purge_expired()
+            entry = self._items.get(key)
+            return entry.payload if entry is not None else None
+
+    def reserve(self, key: str) -> bool:
+        """Reserve ``key`` returning ``False`` if it already exists."""
+
+        with self._lock:
+            self._purge_expired()
+            if key in self._items:
+                return False
+            self._items[key] = _CacheEntry(time.time(), None)
+            return True
+
+
+_CACHE = IdempotencyCache()
+
+
+def build_idempotency_key(
+    symbol: str,
+    side: str,
+    price: float,
+    quantity: float,
+    bucket_seconds: int = 60,
+) -> str:
+    """Return a deterministic key for a trade request bucketed by ``bucket_seconds``."""
+
+    bucket = int(time.time() // bucket_seconds)
+    raw = f"{symbol}|{side}|{round(price, 8)}|{round(quantity, 8)}|{bucket}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def should_submit(key: str) -> bool:
+    """Return ``True`` if ``key`` was not seen recently."""
+
+    return _CACHE.reserve(key)
+
+
+def store_result(key: str, payload: Any) -> None:
+    """Store ``payload`` associated with ``key`` for future retrieval."""
+
+    _CACHE.add(key, payload)
+
+
+def get_cached_result(key: str) -> Optional[Any]:
+    """Return cached result for ``key`` if available."""
+
+    return _CACHE.get(key)
+
+
+def reset_cache(ttl_seconds: float | None = None) -> None:
+    """Reset the in-memory cache, optionally overriding the TTL."""
+
+    global _CACHE
+    ttl = ttl_seconds if ttl_seconds is not None else _CACHE.ttl_seconds
+    _CACHE = IdempotencyCache(ttl_seconds=ttl, max_size=_CACHE.max_size)

--- a/trading_bot/latency.py
+++ b/trading_bot/latency.py
@@ -1,0 +1,27 @@
+"""Latency instrumentation utilities."""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+
+from . import config
+from .metrics import LATENCY_HISTOGRAMS
+
+
+@contextmanager
+def measure_latency(stage: str):
+    """Context manager that records elapsed milliseconds for ``stage``."""
+
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        histogram = LATENCY_HISTOGRAMS.get(stage)
+        if histogram is not None:
+            histogram.observe(elapsed_ms)
+        if elapsed_ms > config.LATENCY_SLO_MS:
+            from .metrics import maybe_alert
+
+            maybe_alert(True, f"Latency SLO exceeded for {stage}: {elapsed_ms:.1f} ms")

--- a/trading_bot/metrics.py
+++ b/trading_bot/metrics.py
@@ -1,6 +1,14 @@
-from prometheus_client import start_http_server, Gauge, Summary
+"""Prometheus metrics and alerting helpers for the trading bot."""
 
-# Basic bot metrics
+from __future__ import annotations
+
+import time
+from typing import Dict
+
+from prometheus_client import Counter, Gauge, Histogram, Summary, start_http_server
+
+from . import notify
+
 open_trades_gauge = Gauge(
     "trading_bot_open_trades",
     "Number of open trades",
@@ -14,13 +22,96 @@ api_latency = Summary(
     "Latency of API calls",
 )
 
+LATENCY_HISTOGRAMS: Dict[str, Histogram] = {
+    "feature_to_prediction": Histogram(
+        "trading_bot_latency_ms_feature_to_prediction",
+        "Feature to prediction latency in milliseconds",
+        buckets=(1, 5, 10, 20, 50, 100, 200, 500, 1000, 2000),
+    ),
+    "submit_to_ack": Histogram(
+        "trading_bot_latency_ms_submit_to_ack",
+        "Order submission to acknowledgement latency in milliseconds",
+        buckets=(1, 5, 10, 20, 50, 100, 200, 500, 1000, 2000),
+    ),
+    "ack_to_filled": Histogram(
+        "trading_bot_latency_ms_ack_to_filled",
+        "Order acknowledgement to filled latency in milliseconds",
+        buckets=(1, 5, 10, 20, 50, 100, 200, 500, 1000, 2000),
+    ),
+}
+
+model_hit_rate_gauge = Gauge(
+    "trading_bot_model_hit_rate_rolling",
+    "Rolling hit rate of the predictive model",
+)
+model_confidence_gauge = Gauge(
+    "trading_bot_model_confidence_mean",
+    "Average model confidence over the rolling window",
+)
+drift_score_gauge = Gauge(
+    "trading_bot_model_drift_score",
+    "Absolute drift between predicted probability and outcomes",
+)
+api_error_counter = Counter(
+    "trading_bot_api_errors_total",
+    "Total number of API errors detected",
+)
+api_retry_counter = Counter(
+    "trading_bot_api_retries_total",
+    "Total number of API retries executed",
+)
+
+_alert_cooldown_seconds = 300
+_last_alert: Dict[str, float] = {}
+
 
 def update_trade_metrics(open_count: int, closed_count: int) -> None:
     """Update open and closed trade gauges."""
+
     open_trades_gauge.set(open_count)
     closed_trades_gauge.set(closed_count)
 
 
 def start_metrics_server(port: int = 8001) -> None:
     """Start an HTTP server exposing Prometheus metrics."""
+
     start_http_server(port)
+
+
+def record_model_performance(hit_rate: float, confidence: float, drift: float) -> None:
+    model_hit_rate_gauge.set(hit_rate)
+    model_confidence_gauge.set(confidence)
+    drift_score_gauge.set(drift)
+
+
+def record_api_error() -> None:
+    api_error_counter.inc()
+
+
+def record_api_retry() -> None:
+    api_retry_counter.inc()
+
+
+def maybe_alert(condition: bool, message: str, *, cooldown: int | None = None) -> None:
+    if not condition:
+        return
+    now = time.time()
+    window = cooldown or _alert_cooldown_seconds
+    last = _last_alert.get(message)
+    if last and now - last < window:
+        return
+    _last_alert[message] = now
+    notify.send_telegram(message)
+    notify.send_discord(message)
+
+
+__all__ = [
+    "LATENCY_HISTOGRAMS",
+    "api_latency",
+    "record_model_performance",
+    "record_api_error",
+    "record_api_retry",
+    "maybe_alert",
+    "start_metrics_server",
+    "update_trade_metrics",
+]

--- a/trading_bot/shadow.py
+++ b/trading_bot/shadow.py
@@ -1,0 +1,59 @@
+"""Shadow trading utilities to benchmark strategies without submitting orders."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable
+
+from . import config
+
+
+@dataclass
+class ShadowConfig:
+    enabled: bool = False
+    compare_modes: Iterable[str] = field(default_factory=lambda: ("heuristic", "hybrid"))
+    record_to: Path = Path("shadow_trades")
+
+
+class ShadowRecorder:
+    def __init__(self, cfg: ShadowConfig) -> None:
+        self.cfg = cfg
+        self._lock = threading.RLock()
+        self.base = Path(cfg.record_to)
+        if cfg.enabled:
+            self.base.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, suffix: str) -> Path:
+        return self.base / f"{suffix}.jsonl"
+
+    def record(self, suffix: str, payload: Dict) -> None:
+        if not self.cfg.enabled:
+            return
+        with self._lock:
+            self.base.mkdir(parents=True, exist_ok=True)
+            path = self._path(suffix)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+_recorder = ShadowRecorder(
+    ShadowConfig(enabled=config.SHADOW_MODE, compare_modes=("heuristic", "hybrid"), record_to=Path("shadow_trades"))
+)
+
+
+def configure(cfg: ShadowConfig) -> None:
+    global _recorder
+    _recorder = ShadowRecorder(cfg)
+
+
+def record_shadow_signal(symbol: str, mode: str, signal_dict: Dict) -> None:
+    payload = {"symbol": symbol, "mode": mode, **signal_dict}
+    _recorder.record("signals", payload)
+
+
+def finalize_shadow_trade(trade_id: str, result_dict: Dict) -> None:
+    payload = {"trade_id": trade_id, **result_dict}
+    _recorder.record("results", payload)

--- a/trading_bot/shutdown.py
+++ b/trading_bot/shutdown.py
@@ -1,0 +1,60 @@
+"""Graceful shutdown helpers for the trading bot."""
+
+from __future__ import annotations
+
+import signal
+import threading
+from typing import Callable, List
+
+_lock = threading.RLock()
+_shutdown_requested = False
+_callbacks: List[Callable[[], None]] = []
+
+
+def _handler(signum, frame):  # pragma: no cover - signal module passes frame
+    request_shutdown()
+
+
+def install_signal_handlers() -> None:
+    """Register SIGINT/SIGTERM handlers to request graceful shutdown."""
+
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+
+
+def request_shutdown() -> None:
+    """Mark shutdown as requested."""
+
+    global _shutdown_requested
+    with _lock:
+        _shutdown_requested = True
+
+
+def shutdown_requested() -> bool:
+    with _lock:
+        return _shutdown_requested
+
+
+def register_callback(callback: Callable[[], None]) -> None:
+    with _lock:
+        _callbacks.append(callback)
+
+
+def execute_callbacks() -> None:
+    with _lock:
+        callbacks = list(_callbacks)
+        _callbacks.clear()
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:  # pragma: no cover - defensive logging handled upstream
+            pass
+
+
+def reset_for_tests() -> None:
+    """Reset shutdown state (intended for unit tests)."""
+
+    global _shutdown_requested
+    with _lock:
+        _shutdown_requested = False
+        _callbacks.clear()

--- a/trading_bot/trade_manager.py
+++ b/trading_bot/trade_manager.py
@@ -58,6 +58,7 @@ def add_trade(trade):
         trade["symbol"] = normalize_symbol(trade.get("symbol", ""))
         if "trade_id" not in trade:
             trade["trade_id"] = str(uuid.uuid4())
+        trade.setdefault("requested_quantity", trade.get("quantity"))
         trade.setdefault(
             "open_time",
             datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),


### PR DESCRIPTION
## Summary
- add a configurable walk-forward/rolling backtest runner that persists trades and KPI reports for later inspection【F:trading_bot/backtest.py†L1-L199】
- harden execution with exchange rule validation, idempotent order submission, latency histograms, and richer Prometheus/alerting hooks【F:trading_bot/exchange_rules.py†L1-L99】【F:trading_bot/idempotency.py†L1-L99】【F:trading_bot/latency.py†L1-L27】【F:trading_bot/metrics.py†L1-L117】【F:trading_bot/execution.py†L300-L420】
- wire shadow-mode, shutdown handling, and new configuration knobs into the trading loop while documenting production practices【F:trading_bot/bot.py†L207-L674】【F:trading_bot/config.py†L137-L200】【F:trading_bot/shadow.py†L1-L59】【F:trading_bot/shutdown.py†L1-L60】【F:README.md†L137-L173】
- extend automated coverage for the new infrastructure, including backtest outputs, rule enforcement, latency metrics, alerts, and shutdown flows【F:tests/test_backtest.py†L1-L62】【F:tests/test_exchange_rules.py†L1-L21】【F:tests/test_idempotency.py†L1-L21】【F:tests/test_latency.py†L1-L18】【F:tests/test_metrics_alerts.py†L1-L15】【F:tests/test_shadow.py†L1-L15】【F:tests/test_shutdown.py†L1-L14】

## Testing
- pytest【352cb4†L1-L78】
- ruff check trading_bot/backtest.py trading_bot/exchange_rules.py trading_bot/idempotency.py trading_bot/latency.py trading_bot/shadow.py trading_bot/shutdown.py【cbe29c†L1-L2】
- mypy --strict trading_bot/backtest.py trading_bot/exchange_rules.py trading_bot/idempotency.py trading_bot/latency.py trading_bot/shadow.py trading_bot/shutdown.py【856ef7†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68cfe727254c8333aedad0d2b6c082ce