### PR TITLE
Follow-up: restore balance fetch and guard CAGR calculation

### DIFF
--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -153,7 +153,11 @@ def compute_kpis(trades: Iterable[TradeResult]) -> dict:
     first_ts = trades_list[0].timestamp
     last_ts = trades_list[-1].timestamp
     years = max((last_ts - first_ts).days / 365.25, 1e-6)
-    cagr = float(((1 + profits.sum()) ** (1 / years)) - 1)
+    cumulative_return = float(profits.sum())
+    if cumulative_return <= -1.0:
+        cagr = float("nan")
+    else:
+        cagr = float(((1 + cumulative_return) ** (1 / years)) - 1)
     std = profits.std(ddof=1) if len(profits) > 1 else 0.0
     sharpe = float(expectancy / std) if std else 0.0
     return {

--- a/trading_bot/execution.py
+++ b/trading_bot/execution.py
@@ -92,6 +92,17 @@ def fetch_balance():
     if exchange is None:
         return 0.0
 
+    if config.TEST_MODE or isinstance(exchange, MockExchange):
+        return 1_000_000.0
+
+    try:
+        bal = _retry_api_call(exchange.fetch_balance, "fetch_balance")
+        usdt = bal.get("USDT", {})
+        return usdt.get("free", 0.0)
+    except Exception as exc:
+        logger.error("Balance fetch error: %s", exc)
+        return 0.0
+
 
 def fetch_position_size(symbol: str) -> float:
     """Return the open contracts for ``symbol`` if any."""
@@ -105,16 +116,6 @@ def fetch_position_size(symbol: str) -> float:
             except (TypeError, ValueError):
                 return 0.0
     return 0.0
-    if config.TEST_MODE or isinstance(exchange, MockExchange):
-        return 1_000_000.0
-
-    try:
-        bal = _retry_api_call(exchange.fetch_balance, "fetch_balance")
-        usdt = bal.get("USDT", {})
-        return usdt.get("free", 0.0)
-    except Exception as exc:
-        logger.error("Balance fetch error: %s", exc)
-        return 0.0
 
 
 def fetch_order_status(order_id: str, symbol: str) -> str:


### PR DESCRIPTION
## Summary
- add a configurable walk-forward/rolling backtest runner that persists trades and KPI reports for later inspection
- harden execution with exchange rule validation, idempotent order submission, latency histograms, and richer Prometheus/alerting hooks
- wire shadow-mode, shutdown handling, and new configuration knobs into the trading loop while documenting production practices
- extend automated coverage for the new infrastructure, including backtest outputs, rule enforcement, latency metrics, alerts, and shutdown flows
- introduce a runtime mode selector with CLI/env/interactive entry points that toggle trading, shadow, testnet, and backtest behaviours without breaking existing defaults
- restore `fetch_balance`'s real exchange path and remove unreachable code after the `fetch_position_size` addition
- guard `compute_kpis` CAGR calculation when cumulative returns fall at or below -100%

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0118267a4833381b48fff60e5b422