### PR TITLE
Integrate shadow finalization and unify training pipeline

### DIFF
--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -22,3 +22,48 @@ def test_shadow_records_to_disk(tmp_path):
     assert results_path.exists()
     assert "BTCUSDT" in signals_path.read_text(encoding="utf-8")
     assert "trade-1" in results_path.read_text(encoding="utf-8")
+
+
+def test_shadow_integration_records_results(monkeypatch):
+    from trading_bot import bot
+
+    bot._reset_shadow_positions()
+    monkeypatch.setattr(bot.config, "SHADOW_MODE", True)
+
+    recorded: list[tuple[str, str, dict]] = []
+    finalized: list[tuple[str, dict]] = []
+
+    def fake_record(symbol, mode, payload):
+        recorded.append((symbol, mode, payload))
+
+    def fake_finalize(trade_id, payload):
+        finalized.append((trade_id, payload))
+
+    monkeypatch.setattr(bot.shadow, "record_shadow_signal", fake_record)
+    monkeypatch.setattr(bot.shadow, "finalize_shadow_trade", fake_finalize)
+
+    signal = {
+        "symbol": "AAA_USDT",
+        "side": "BUY",
+        "quantity": 1.0,
+        "entry_price": 100.0,
+        "take_profit": 110.0,
+        "stop_loss": 95.0,
+        "prob_success": 0.7,
+        "orig_prob": 0.55,
+        "leverage": 1,
+    }
+
+    bot.open_new_trade(signal)
+    assert len(recorded) == 2
+    trade_ids = {payload["trade_id"] for _, _, payload in recorded}
+    assert all(":" in tid for tid in trade_ids)
+
+    monkeypatch.setattr(bot.data, "get_current_price_ticker", lambda symbol: 111.0)
+    profit = bot._process_shadow_positions()
+
+    assert profit > 0
+    assert len(finalized) == 2
+    modes = {payload["mode"] for _, payload in finalized}
+    assert modes == {"heuristic", "hybrid"}
+    bot._reset_shadow_positions()

--- a/trading_bot/train_model.py
+++ b/trading_bot/train_model.py
@@ -1,30 +1,85 @@
+"""Minimal CLI wrapper around :mod:`trading_bot.predictive_model`.
+
+This script is retained for backwards compatibility with earlier automation
+that depended on ``trading_bot.train_model``. Internally it now delegates to the
+more feature-rich :mod:`trading_bot.predictive_model` utilities to avoid
+maintaining two independent training paths.
+"""
+
+from __future__ import annotations
+
 import argparse
-import pandas as pd
-from . import optimizer
+
+from .predictive_model import TrainingConfig, evaluate_model, save_model, train_model
 
 
-def main():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Train ML model for trading bot"
+        description="Train a machine-learning model for the trading bot",
     )
     parser.add_argument("csv", help="CSV file with training data")
     parser.add_argument(
         "--target",
         default="target",
-        help="Target column name",
+        help="Target column name (default: %(default)s)",
     )
     parser.add_argument(
-        "--model",
+        "--output",
         default="model.pkl",
-        help="Output model path",
+        help="Output model path (default: %(default)s)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--model-type",
+        choices=("logistic", "random_forest"),
+        default="random_forest",
+        help="Underlying estimator to use (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--cv-splits",
+        type=int,
+        default=3,
+        help="Number of time-series CV splits (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--no-calibration",
+        action="store_true",
+        help="Disable probability calibration after training",
+    )
+    parser.add_argument(
+        "--print-metrics",
+        action="store_true",
+        help="Evaluate the trained model on the training set and print metrics",
+    )
+    return parser.parse_args()
 
-    df = pd.read_csv(args.csv)
-    model = optimizer.optimize_model(df, args.target)
-    optimizer.save_model(model, args.model)
-    print(f"Model saved to {args.model}")
+
+def main() -> int:
+    args = parse_args()
+    cfg = TrainingConfig(
+        model_type=args.model_type,
+        cv_splits=args.cv_splits,
+        calibrate_probabilities=not args.no_calibration,
+    )
+
+    model = train_model(args.csv, args.target, cfg)
+    save_model(model, args.output)
+    print(f"Model saved to {args.output}")
+
+    if args.print_metrics:
+        # Lazily import pandas to keep the CLI lightweight when metrics are not required.
+        import pandas as pd
+
+        frame = pd.read_csv(args.csv)
+        X = frame.drop(columns=[args.target])
+        y = frame[args.target]
+        metrics = evaluate_model(model, X, y)
+        for key, value in metrics.items():
+            if isinstance(value, float):
+                print(f"{key}: {value:.4f}")
+            else:
+                print(f"{key}: {value}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- track shadow-mode entries using dedicated state so results are finalized and logged when exit conditions trigger
- refactor the legacy optimizer and CLI training script to delegate to the shared predictive_model helpers, avoiding duplicated training flows
- extend predictive_model with dataframe-based training support and add coverage for the new shadow finalization path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0170a83448333be6a0f1f431f91e7