### PR TITLE
Restore --model flag alias in legacy training CLI

### DIFF
--- a/trading_bot/train_model.py
+++ b/trading_bot/train_model.py
@@ -25,6 +25,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output",
+        "--model",
+        dest="output",
         default="model.pkl",
         help="Output model path (default: %(default)s)",
     )


### PR DESCRIPTION
## Summary
- allow both --output and --model flags in trading_bot.train_model for backwards compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01f40a0f48333b2243d6100668d47