### PR TITLE
Handle identical manifests when promoting models

### DIFF
--- a/trading_bot/model_ops.py
+++ b/trading_bot/model_ops.py
@@ -47,6 +47,12 @@ def promote(candidate_model: Path, candidate_manifest: Path, prod_model: Path, p
     prod_model.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(candidate_model, prod_model)
     if candidate_manifest.exists():
+        try:
+            if candidate_manifest.resolve() == prod_manifest.resolve():
+                return
+        except OSError:
+            # If resolution fails we conservatively attempt the copy below.
+            pass
         shutil.copy2(candidate_manifest, prod_manifest)
 
 


### PR DESCRIPTION
## Summary
- skip copying the manifest when the candidate and production paths resolve to the same file to avoid SameFileError
- guard the manifest copy with a resolve() check so the promotion flow continues even when paths overlap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d061b43f148333bf32bc383c20b103