### PR TITLE
Improve trade lifecycle handling and websocket resilience

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import trading_bot.config as config
 import trading_bot.trade_manager as tm
-from trading_bot.state_machine import TradeState, InvalidStateTransition
+from trading_bot.state_machine import TradeState
 
 tm.reset_state()
 
@@ -44,8 +44,8 @@ def test_set_trade_state(monkeypatch):
     tid = t["trade_id"]
     tm.set_trade_state(tid, TradeState.OPEN)
     assert t["state"] == TradeState.OPEN.value
-    with pytest.raises(InvalidStateTransition):
-        tm.set_trade_state(tid, TradeState.PENDING)
+    assert not tm.set_trade_state(tid, TradeState.PENDING)
+    assert t["state"] == TradeState.OPEN.value
 
 
 def test_close_trade_forces_closing(monkeypatch):

--- a/tests/test_trade_manager_state.py
+++ b/tests/test_trade_manager_state.py
@@ -1,6 +1,6 @@
 import unittest
 from trading_bot import trade_manager as tm
-from trading_bot.state_machine import TradeState, InvalidStateTransition
+from trading_bot.state_machine import TradeState
 
 
 class TestTradeManagerWithState(unittest.TestCase):
@@ -30,8 +30,11 @@ class TestTradeManagerWithState(unittest.TestCase):
 
     def test_invalid_transition(self):
         tm.add_trade({"trade_id": "T2", "symbol": "ETH_USDT"})
-        with self.assertRaises(InvalidStateTransition):
-            tm.set_trade_state("T2", TradeState.CLOSED)
+        result = tm.set_trade_state("T2", TradeState.CLOSED)
+        self.assertFalse(result)
+        self.assertEqual(
+            tm.find_trade(trade_id="T2")["state"], TradeState.PENDING.value
+        )
 
 
 if __name__ == "__main__":

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -119,6 +119,16 @@ RUN_BACKTEST_ON_START = False
 BACKTEST_CONFIG_PATH = os.getenv("BACKTEST_CONFIG_PATH")
 BACKTEST_DATA_PATH = os.getenv("BACKTEST_DATA_PATH")
 
+# ===== Order lifecycle & timeouts =====
+PENDING_FILL_TIMEOUT_S = _int_env("PENDING_FILL_TIMEOUT_S", 30, clamp=(1, 600))
+RECONCILE_INTERVAL_S = _int_env("RECONCILE_INTERVAL_S", 5, clamp=(1, 300))
+
+# ===== WebSocket resilience =====
+WS_PING_INTERVAL_S = _int_env("WS_PING_INTERVAL_S", 25, clamp=(5, 120))
+WS_PONG_TIMEOUT_S = _int_env("WS_PONG_TIMEOUT_S", 10, clamp=(3, 60))
+WS_BACKOFF_MIN_S = _int_env("WS_BACKOFF_MIN_S", 2, clamp=(1, 60))
+WS_BACKOFF_MAX_S = _int_env("WS_BACKOFF_MAX_S", 60, clamp=(WS_BACKOFF_MIN_S, 600))
+
 TRADING_MODE = os.getenv("TRADING_MODE", "paper").strip().lower()
 ALLOW_LIVE_TRADING = os.getenv("ALLOW_LIVE_TRADING", "0") == "1"
 LIVE_TRADING_TOKEN_PATH = os.getenv("LIVE_TRADING_TOKEN_PATH", "")

--- a/trading_bot/reconcile.py
+++ b/trading_bot/reconcile.py
@@ -1,0 +1,75 @@
+"""Helpers to reconcile pending trades when the websocket desynchronises."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Iterable
+
+from . import config, execution, trade_manager
+from .state_machine import TradeState
+
+logger = logging.getLogger(__name__)
+
+
+def _state_from_trade(trade: dict) -> TradeState:
+    try:
+        return TradeState(trade.get("state"))
+    except ValueError:
+        return TradeState.PENDING
+
+
+def reconcile_pending_trades(trades: Iterable[dict] | None = None) -> None:
+    """Poll REST endpoints to promote or cancel stale pending trades."""
+
+    now = time.time()
+    active = list(trades) if trades is not None else trade_manager.all_open_trades()
+    for trade in active:
+        state = _state_from_trade(trade)
+        if state != TradeState.PENDING:
+            continue
+
+        trade_id = trade.get("trade_id")
+        symbol = trade.get("symbol", "")
+        created = float(trade.get("created_ts") or trade.get("created_at") or now)
+        age = now - created
+        if age >= config.PENDING_FILL_TIMEOUT_S:
+            logger.info(
+                "Cancel PENDING by timeout: trade_id=%s symbol=%s age=%.1fs",
+                trade_id,
+                symbol,
+                age,
+            )
+            order_id = trade.get("order_id")
+            if order_id and not config.DRY_RUN:
+                try:
+                    execution.cancel_order(order_id, symbol)
+                except Exception as exc:  # pragma: no cover - network errors
+                    logger.debug(
+                        "Cancel order %s failed during reconcile: %s", order_id, exc
+                    )
+            trade_manager.cancel_pending_trade(trade_id, reason="pending_timeout")
+            continue
+
+        if config.DRY_RUN:
+            continue
+
+        order_id = trade.get("order_id")
+        if not order_id:
+            continue
+
+        status = execution.fetch_order_status(order_id, symbol)
+        status = (status or "").lower()
+        if status in {"filled"}:
+            logger.info("Trade %s filled via REST fallback", trade_id)
+            opened_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            trade_manager.update_trade(trade_id, open_time=opened_at)
+            trade_manager.set_trade_state(trade_id, TradeState.OPEN)
+        elif status in {"partial"}:
+            logger.info("Trade %s partially filled via REST fallback", trade_id)
+            trade_manager.set_trade_state(trade_id, TradeState.OPEN)
+            trade_manager.set_trade_state(trade_id, TradeState.PARTIALLY_FILLED)
+        elif status in {"canceled", "rejected", "expired"}:
+            logger.info("Trade %s cancelled at exchange while pending", trade_id)
+            trade_manager.cancel_pending_trade(trade_id, reason=status)


### PR DESCRIPTION
## Summary
- add configuration knobs for pending trade reconciliation and websocket resilience
- guard trade state transitions, support cancelling stale pending orders, and add REST reconciliation for websocket dropouts
- simulate fills in dry-run mode, avoid leverage/orders when testing, and harden the websocket client with ping/pong and exponential backoff

## Testing
- pytest tests/test_trade_manager.py tests/test_trade_manager_state.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1851107c83338996e1dd5becf616