### PR TITLE
Redesign trading dashboard with live metrics

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,8 +1,9 @@
 from trading_bot.webapp import app
+from trading_bot import webapp as webapp_module
 from trading_bot.trade_manager import open_trades, closed_trades
 
 
-def test_webapp_endpoints():
+def test_webapp_endpoints(tmp_path, monkeypatch):
     """Prueba que los endpoints /api/trades y /api/liquidity devuelven datos válidos."""
     open_trades.clear()
     closed_trades.clear()
@@ -14,6 +15,14 @@ def test_webapp_endpoints():
         "side": "BUY",
     })
 
+    history_file = tmp_path / "trade_history.csv"
+    history_file.write_text(
+        "symbol,side,quantity,entry_price,exit_price,take_profit,stop_loss,profit,open_time,close_time\n"
+        "BTC_USDT,BUY,1.0,100.0,110.0,0,0,10.0,2024-01-01T00:00:00,2024-01-01T01:00:00\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(webapp_module, "HISTORY_FILE", history_file)
+
     with app.test_client() as client:
         resp = client.get("/api/trades")
         assert resp.status_code == 200
@@ -24,3 +33,15 @@ def test_webapp_endpoints():
         resp2 = client.get("/api/liquidity")
         assert resp2.status_code == 200
         assert isinstance(resp2.get_json(), dict)
+
+        summary_resp = client.get("/api/summary")
+        assert summary_resp.status_code == 200
+        summary = summary_resp.get_json()
+        assert summary["total_positions"] == 1
+        assert summary["per_symbol"][0]["symbol"] == "BTC_USDT"
+
+        history_resp = client.get("/api/history")
+        assert history_resp.status_code == 200
+        history_data = history_resp.get_json()
+        assert isinstance(history_data, list)
+        assert history_data[0]["symbol"] == "BTC_USDT"

--- a/trading_bot/static/css/dashboard.css
+++ b/trading_bot/static/css/dashboard.css
@@ -1,0 +1,219 @@
+:root {
+    --brand-primary: #3f51b5;
+    --brand-secondary: #00bcd4;
+    --surface: rgba(255, 255, 255, 0.92);
+    --surface-dark: #12172a;
+    --success: #1abc9c;
+    --danger: #e74c3c;
+}
+
+body {
+    background: radial-gradient(circle at top left, #182848, #060b23 65%);
+    min-height: 100vh;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: #f8f9ff;
+}
+
+.navbar {
+    background: linear-gradient(120deg, rgba(41, 72, 189, 0.95), rgba(11, 191, 189, 0.9));
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(8px);
+}
+
+.navbar-brand span {
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+main.container-fluid {
+    max-width: 1400px;
+}
+
+.card {
+    background: var(--surface);
+    color: #1b243b;
+    border: none;
+    border-radius: 18px;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.24);
+    overflow: hidden;
+}
+
+.card-header {
+    background: rgba(15, 23, 42, 0.04);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.metric-card .metric-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(16, 24, 40, 0.6);
+}
+
+.metric-card .metric-value {
+    font-size: 2.2rem;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.metric-card .metric-delta {
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.badge-status {
+    font-size: 0.7rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.table thead th {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    border-bottom: none;
+    background: rgba(15, 23, 42, 0.85);
+    color: #fff;
+    vertical-align: middle;
+}
+
+.table tbody td {
+    vertical-align: middle;
+}
+
+.table tbody tr:hover {
+    background-color: rgba(33, 150, 243, 0.08);
+}
+
+.trade-side {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+}
+
+.trade-side.buy {
+    color: var(--success);
+}
+
+.trade-side.sell {
+    color: var(--danger);
+}
+
+.pnl-positive {
+    color: var(--success);
+    font-weight: 600;
+}
+
+.pnl-negative {
+    color: var(--danger);
+    font-weight: 600;
+}
+
+.symbol-badge {
+    font-weight: 700;
+    color: #0b1736;
+    background: linear-gradient(135deg, rgba(63, 81, 181, 0.18), rgba(63, 81, 181, 0.45));
+    border-radius: 999px;
+    padding: 0.25rem 0.8rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.symbol-badge i {
+    font-size: 0.75rem;
+    color: rgba(14, 36, 75, 0.7);
+}
+
+.symbol-breakdown .list-group-item {
+    border: none;
+    background: rgba(63, 81, 181, 0.08);
+    border-radius: 12px;
+    margin-bottom: 0.6rem;
+    padding: 0.9rem 1rem;
+    color: #19233f;
+}
+
+.symbol-breakdown .list-group-item:last-child {
+    margin-bottom: 0;
+}
+
+.symbol-breakdown .badge {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.liquidity-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.liquidity-grid .orderbook-card {
+    background: rgba(15, 23, 42, 0.05);
+    border-radius: 16px;
+    padding: 1rem;
+}
+
+.orderbook-card table {
+    font-size: 0.85rem;
+}
+
+.orderbook-card thead {
+    background: rgba(15, 23, 42, 0.05);
+}
+
+.orderbook-card tbody tr td:first-child {
+    font-weight: 600;
+}
+
+.history-list {
+    max-height: 320px;
+    overflow-y: auto;
+    display: grid;
+    gap: 0.8rem;
+}
+
+.history-item {
+    background: rgba(63, 81, 181, 0.08);
+    border-radius: 14px;
+    padding: 0.8rem 1rem;
+    color: #16213e;
+    display: grid;
+    gap: 0.25rem;
+}
+
+.history-item .side-buy {
+    color: var(--success);
+    font-weight: 600;
+}
+
+.history-item .side-sell {
+    color: var(--danger);
+    font-weight: 600;
+}
+
+#globalAlerts .alert {
+    border-radius: 14px;
+}
+
+.footer {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 992px) {
+    .metric-card .metric-value {
+        font-size: 1.8rem;
+    }
+
+    .liquidity-grid {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+}
+
+@media (min-width: 993px) {
+    .liquidity-grid {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+}

--- a/trading_bot/static/js/dashboard.js
+++ b/trading_bot/static/js/dashboard.js
@@ -1,0 +1,398 @@
+const REFRESH_INTERVAL = 10000;
+const MAX_POINTS = 60;
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+});
+
+const quantityFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+});
+
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const state = {
+  trades: [],
+  summary: null,
+  history: [],
+  liquidity: {},
+  symbolFilter: '',
+  pnlSeries: [],
+};
+
+let pnlChart = null;
+
+async function fetchJSON(url) {
+  const response = await fetch(url, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}`);
+  }
+  return response.json();
+}
+
+function setStatus(label, variant) {
+  const badge = document.getElementById('connectionStatus');
+  badge.textContent = label;
+  badge.className = `badge badge-status bg-${variant}`;
+}
+
+function showAlert(message, variant = 'danger') {
+  const container = document.getElementById('globalAlerts');
+  if (!container) return;
+  container.innerHTML = `
+    <div class="alert alert-${variant} alert-dismissible fade show" role="alert">
+      ${message}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>`;
+}
+
+function clearAlert() {
+  const container = document.getElementById('globalAlerts');
+  if (container) {
+    container.innerHTML = '';
+  }
+}
+
+function formatNumber(value, formatter = numberFormatter) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '—';
+  }
+  return formatter.format(numeric);
+}
+
+function formatPnL(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '—';
+  }
+  const prefix = numeric > 0 ? '+' : '';
+  return `${prefix}${numberFormatter.format(numeric)}`;
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function ensureChart() {
+  if (pnlChart) {
+    return pnlChart;
+  }
+  const ctx = document.getElementById('pnlChart');
+  if (!ctx) {
+    return null;
+  }
+  pnlChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'PnL no realizado',
+          data: [],
+          borderColor: '#2b6cb0',
+          backgroundColor: 'rgba(66, 153, 225, 0.25)',
+          tension: 0.35,
+          fill: true,
+          borderWidth: 2,
+          pointRadius: 0,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              return formatPnL(context.parsed.y);
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: '#5b6478',
+          },
+          grid: {
+            color: 'rgba(91, 100, 120, 0.15)',
+          },
+        },
+        y: {
+          ticks: {
+            color: '#5b6478',
+            callback(value) {
+              return formatNumber(value);
+            },
+          },
+          grid: {
+            color: 'rgba(91, 100, 120, 0.15)',
+          },
+        },
+      },
+    },
+  });
+  return pnlChart;
+}
+
+function updatePnlSeries(summary) {
+  if (!summary) return;
+  const chart = ensureChart();
+  if (!chart) return;
+
+  const timestampLabel = new Date(summary.generated_at || Date.now()).toLocaleTimeString();
+  const currentValue = Number(summary.unrealized_pnl) || 0;
+
+  state.pnlSeries.push({ label: timestampLabel, value: currentValue });
+  if (state.pnlSeries.length > MAX_POINTS) {
+    state.pnlSeries.shift();
+  }
+
+  chart.data.labels = state.pnlSeries.map((item) => item.label);
+  chart.data.datasets[0].data = state.pnlSeries.map((item) => item.value);
+  chart.update('none');
+}
+
+function renderSummary(summary) {
+  if (!summary) return;
+  document.getElementById('metricPositions').textContent = summary.total_positions;
+  document.getElementById('metricPnL').textContent = formatPnL(summary.unrealized_pnl);
+  document.getElementById('metricExposure').textContent = formatNumber(summary.gross_notional);
+  document.getElementById('metricWinRate').textContent = formatNumber(summary.win_rate, percentFormatter);
+  document.getElementById('lastUpdated').textContent = new Date(summary.generated_at).toLocaleTimeString();
+
+  const list = document.getElementById('symbolBreakdown');
+  if (!list) return;
+  list.innerHTML = '';
+  if (!summary.per_symbol || summary.per_symbol.length === 0) {
+    list.innerHTML = '<li class="list-group-item">Sin posiciones abiertas.</li>';
+    return;
+  }
+
+  summary.per_symbol.forEach((item) => {
+    const pnlClass = item.unrealized_pnl >= 0 ? 'text-success' : 'text-danger';
+    const exposure = formatNumber(item.exposure, quantityFormatter);
+    const pnl = formatPnL(item.unrealized_pnl);
+    const notional = formatNumber(item.notional_value);
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex flex-column flex-sm-row align-items-sm-center justify-content-between';
+    li.innerHTML = `
+      <div class="d-flex align-items-center gap-2 mb-2 mb-sm-0">
+        <span class="symbol-badge"><i class="bi bi-graph-up"></i>${item.symbol}</span>
+        <span class="badge bg-dark-subtle text-dark">${item.positions} posiciones</span>
+      </div>
+      <div class="d-flex flex-wrap gap-3">
+        <span><strong>Exposición:</strong> ${exposure}</span>
+        <span><strong>Notional:</strong> ${notional}</span>
+        <span class="${pnlClass}"><strong>PnL:</strong> ${pnl}</span>
+      </div>`;
+    list.appendChild(li);
+  });
+}
+
+function renderTrades() {
+  const tbody = document.getElementById('tradesTableBody');
+  if (!tbody) return;
+
+  const filter = state.symbolFilter.trim().toLowerCase();
+  const trades = filter
+    ? state.trades.filter((trade) => String(trade.symbol || '').toLowerCase().includes(filter))
+    : state.trades;
+
+  if (!trades || trades.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="9" class="text-center text-muted py-4">No hay operaciones abiertas.</td></tr>';
+    return;
+  }
+
+  const rows = trades
+    .map((trade) => {
+      const side = String(trade.side || '').toLowerCase();
+      const sideClass = side === 'buy' ? 'buy' : 'sell';
+      const pnlClass = trade.pnl_unrealized >= 0 ? 'pnl-positive' : 'pnl-negative';
+      const currentPrice = formatNumber(trade.current_price, priceFormatter);
+      const entryPrice = formatNumber(trade.entry_price, priceFormatter);
+      const takeProfit = formatNumber(trade.take_profit, priceFormatter);
+      const stopLoss = formatNumber(trade.stop_loss, priceFormatter);
+      const quantity = formatNumber(trade.quantity, quantityFormatter);
+      const pnl = formatPnL(trade.pnl_unrealized);
+      return `
+        <tr>
+          <td><span class="symbol-badge"><i class="bi bi-currency-bitcoin"></i>${trade.symbol}</span></td>
+          <td class="trade-side ${sideClass}">${side.toUpperCase()}</td>
+          <td>${quantity}</td>
+          <td>${entryPrice}</td>
+          <td>${currentPrice}</td>
+          <td>${takeProfit}</td>
+          <td>${stopLoss}</td>
+          <td class="${pnlClass}">${pnl}</td>
+          <td>${trade.open_time ? formatDate(trade.open_time) : '—'}</td>
+        </tr>`;
+    })
+    .join('');
+
+  tbody.innerHTML = rows;
+}
+
+function renderLiquidity() {
+  const container = document.getElementById('liquidityContainer');
+  if (!container) return;
+
+  const entries = Object.entries(state.liquidity || {});
+  if (entries.length === 0) {
+    container.innerHTML = '<div class="text-muted text-center py-4">No hay datos de liquidez disponibles.</div>';
+    return;
+  }
+
+  const html = entries
+    .map(([symbol, book]) => {
+      const bids = (book.bids || []).slice(0, 5);
+      const asks = (book.asks || []).slice(0, 5);
+      const rows = [];
+      for (let i = 0; i < Math.max(bids.length, asks.length); i += 1) {
+        const bid = bids[i] || ['—', '—'];
+        const ask = asks[i] || ['—', '—'];
+        rows.push(`
+          <tr>
+            <td class="text-success">${formatNumber(bid[0], priceFormatter)}</td>
+            <td class="text-success">${formatNumber(bid[1], quantityFormatter)}</td>
+            <td class="text-danger">${formatNumber(ask[0], priceFormatter)}</td>
+            <td class="text-danger">${formatNumber(ask[1], quantityFormatter)}</td>
+          </tr>`);
+      }
+      return `
+        <div class="orderbook-card">
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <span class="symbol-badge"><i class="bi bi-lightning"></i>${symbol}</span>
+            <span class="badge bg-secondary-subtle text-dark">Top 5 niveles</span>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-sm mb-0">
+              <thead>
+                <tr>
+                  <th class="text-success">Bid</th>
+                  <th class="text-success">Cantidad</th>
+                  <th class="text-danger">Ask</th>
+                  <th class="text-danger">Cantidad</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${rows.join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>`;
+    })
+    .join('');
+
+  container.innerHTML = `<div class="liquidity-grid">${html}</div>`;
+}
+
+function renderHistory() {
+  const container = document.getElementById('historyList');
+  if (!container) return;
+
+  if (!state.history || state.history.length === 0) {
+    container.innerHTML = '<div class="text-center text-muted">Sin operaciones cerradas recientes.</div>';
+    return;
+  }
+
+  const items = state.history
+    .map((trade) => {
+      const side = String(trade.side || '').toLowerCase();
+      const sideLabel = side === 'buy' ? 'Compra' : 'Venta';
+      const pnlClass = Number(trade.profit) >= 0 ? 'text-success' : 'text-danger';
+      return `
+        <div class="history-item">
+          <div class="d-flex justify-content-between align-items-center">
+            <span class="symbol-badge"><i class="bi bi-clock-history"></i>${trade.symbol || '—'}</span>
+            <span class="${side === 'buy' ? 'side-buy' : 'side-sell'}">${sideLabel}</span>
+          </div>
+          <div class="d-flex flex-wrap gap-3">
+            <span><strong>Entrada:</strong> ${formatNumber(trade.entry_price, priceFormatter)}</span>
+            <span><strong>Salida:</strong> ${formatNumber(trade.exit_price, priceFormatter)}</span>
+            <span class="${pnlClass}"><strong>PnL:</strong> ${formatPnL(trade.profit)}</span>
+          </div>
+          <div class="text-muted small">${formatDate(trade.open_time)} → ${formatDate(trade.close_time)}</div>
+        </div>`;
+    })
+    .join('');
+
+  container.innerHTML = items;
+}
+
+async function refreshDashboard(manual = false) {
+  try {
+    if (manual) {
+      setStatus('Actualizando…', 'info');
+    }
+    clearAlert();
+    const [trades, summary, liquidity, history] = await Promise.all([
+      fetchJSON('/api/trades'),
+      fetchJSON('/api/summary'),
+      fetchJSON('/api/liquidity'),
+      fetchJSON('/api/history?limit=15').catch(() => []),
+    ]);
+
+    state.trades = trades;
+    state.summary = summary;
+    state.liquidity = liquidity;
+    state.history = history;
+
+    renderTrades();
+    renderSummary(summary);
+    renderLiquidity();
+    renderHistory();
+    updatePnlSeries(summary);
+    setStatus('En vivo', 'success');
+  } catch (error) {
+    console.error(error);
+    showAlert('No se pudieron sincronizar los datos del bot. Reintentaremos automáticamente.', 'danger');
+    setStatus('Desconectado', 'danger');
+  }
+}
+
+function attachEvents() {
+  const filterInput = document.getElementById('symbolFilter');
+  if (filterInput) {
+    filterInput.addEventListener('input', (event) => {
+      state.symbolFilter = event.target.value;
+      renderTrades();
+    });
+  }
+
+  const refreshBtn = document.getElementById('refreshTradesBtn');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => refreshDashboard(true));
+  }
+}
+
+function initialize() {
+  ensureChart();
+  attachEvents();
+  refreshDashboard();
+  setStatus('Sincronizando…', 'warning');
+  setInterval(refreshDashboard, REFRESH_INTERVAL);
+}
+
+document.addEventListener('DOMContentLoaded', initialize);

--- a/trading_bot/templates/index.html
+++ b/trading_bot/templates/index.html
@@ -1,148 +1,173 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="utf-8">
     <title>Trading Bot Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Bootstrap 5 CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body { background: #f5f6fa; }
-        .table thead th { background-color: #222c3d; color: #fff; }
-        .buy { color: #1abc9c; font-weight: bold; }
-        .sell { color: #e74c3c; font-weight: bold; }
-        .container { max-width: 900px; margin-top: 40px; }
-        h1 { font-size: 2.5rem; margin-bottom: 1rem; color: #222c3d;}
-        .card { box-shadow: 0 2px 12px 0 rgba(60,60,100,0.06); }
-        .table { border-radius: 12px; overflow: hidden; }
-        #splash {
-            position: fixed;
-            z-index: 9999;
-            inset: 0;
-            background: #000;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            transition: opacity 0.7s cubic-bezier(.7,.4,.6,1);
-            opacity: 1;
-        }
-        #splash.hide {
-            opacity: 0;
-            pointer-events: none;
-        }
-        #splash-title {
-            color: #fff;
-            font-size: 6vw;
-            font-weight: 900;
-            letter-spacing: 0.04em;
-            animation: zoomin 1s cubic-bezier(.4,.6,0.3,1.2);
-            text-shadow: 0 0 40px #fff5, 0 4px 30px #0af4;
-        }
-        @keyframes zoomin {
-            from { transform: scale(1.1); opacity: 1; }
-            80%  { transform: scale(1.01); opacity: 1; }
-            to   { transform: scale(1.17); opacity: 1; }
-        }
-        @media (max-width:600px){
-            #splash-title{font-size:12vw;}
-        }
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/dashboard.css') }}" rel="stylesheet">
 </head>
 <body>
-    <div id="splash">
-        <div id="splash-title">Patatabot</div>
-    </div>
-    <div class="container" id="main-content" style="opacity:0; filter: blur(6px); transition: opacity .6s, filter .7s;">
-        <div class="card p-4">
-            <h1 class="text-center">Trading Bot Dashboard</h1>
-            <div class="text-center mb-3">
-                <button id="btnTrades" class="btn btn-primary me-2">Mostrar Trades</button>
-                <button id="btnLiquidity" class="btn btn-secondary">Mostrar Liquidez</button>
+    <nav class="navbar navbar-expand-lg navbar-dark">
+        <div class="container-fluid px-4">
+            <a class="navbar-brand" href="#">
+                <span>Patatabot</span>
+            </a>
+            <div class="d-flex align-items-center gap-3">
+                <span class="badge badge-status bg-warning text-dark" id="connectionStatus">Sincronizando…</span>
+                <button class="btn btn-sm btn-outline-light" id="refreshTradesBtn">
+                    <i class="bi bi-arrow-repeat"></i>
+                    Actualizar ahora
+                </button>
             </div>
-            <table class="table table-hover table-bordered align-middle text-center mb-0">
-                <thead>
-                    <tr>
-                        <th>Symbol</th>
-                        <th>Side</th>
-                        <th>Qty</th>
-                        <th>Entry</th>
-                        <th>TP</th>
-                        <th>SL</th>
-                        <th>PnL</th>
-                    </tr>
-                </thead>
-                <tbody id="ops">
-                    <tr>
-                        <td colspan="7" class="text-secondary py-4">Pulsa "Mostrar Trades" para cargar datos.</td>
-                    </tr>
-                </tbody>
-            </table>
-            <div id="liquidityContainer" class="mt-4"></div>
         </div>
-        <div class="text-center mt-4 text-muted small">
-            &copy; 2025 Trading Bot Dashboard · Powered by Flask & Bootstrap
+    </nav>
+
+    <main class="container-fluid py-4 px-4 px-xl-5">
+        <div id="globalAlerts" class="mb-3"></div>
+
+        <div class="row g-3">
+            <div class="col-12 col-md-6 col-xl-3">
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <div class="metric-label">Posiciones abiertas</div>
+                        <div class="metric-value" id="metricPositions">0</div>
+                        <div class="metric-delta text-muted">Número total de operaciones activas</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-3">
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <div class="metric-label">PnL no realizado</div>
+                        <div class="metric-value" id="metricPnL">0.00</div>
+                        <div class="metric-delta text-muted">Actualizado en tiempo real</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-3">
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <div class="metric-label">Exposición nocional</div>
+                        <div class="metric-value" id="metricExposure">0.00</div>
+                        <div class="metric-delta text-muted">Suma de capital comprometido</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-3">
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <div class="metric-label">Win rate</div>
+                        <div class="metric-value" id="metricWinRate">0%</div>
+                        <div class="metric-delta text-muted">Operaciones en verde vs. en rojo</div>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-    <script>
-        setTimeout(function() {
-            document.getElementById('splash').classList.add('hide');
-            document.getElementById('main-content').style.opacity = '1';
-            document.getElementById('main-content').style.filter = 'blur(0)';
-        }, 1100); // 1.1s para que la animación de zoom acabe antes de ocultar
-        const REFRESH_INTERVAL = 10;
 
+        <div class="row g-3 mt-1">
+            <div class="col-12 col-xl-8">
+                <div class="card h-100">
+                    <div class="card-header d-flex align-items-center justify-content-between">
+                        <div>
+                            <h2 class="h5 mb-0">Evolución del PnL</h2>
+                            <p class="text-muted mb-0 small">Seguimiento continuo de la exposición del bot</p>
+                        </div>
+                        <small class="text-muted" id="lastUpdated">Sin datos</small>
+                    </div>
+                    <div class="card-body" style="height: 320px;">
+                        <canvas id="pnlChart" aria-label="Gráfico de PnL"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-xl-4">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h2 class="h5 mb-0">Exposición por símbolo</h2>
+                    </div>
+                    <div class="card-body">
+                        <ul class="list-group list-group-flush symbol-breakdown" id="symbolBreakdown">
+                            <li class="list-group-item">Sin posiciones abiertas.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-        async function loadTrades() {
-            try {
-                let resp = await fetch('/api/trades');
-                let trades = await resp.json();
-                let html = '';
-                if (trades && trades.length > 0) {
-                    for (const t of trades) {
-                        const pnlClass = t.pnl_unrealized >= 0 ? 'text-success' : 'text-danger';
-                        html += `<tr>
-                            <td><span class="badge bg-primary">${t.symbol}</span></td>
-                            <td class="${t.side && t.side.toLowerCase() === 'buy' ? 'buy' : 'sell'}">${t.side ? t.side.charAt(0).toUpperCase() + t.side.slice(1) : ''}</td>
-                            <td>${t.quantity}</td>
-                            <td>${parseFloat(t.entry_price).toFixed(4)}</td>
-                            <td>${parseFloat(t.take_profit).toFixed(4)}</td>
-                            <td>${parseFloat(t.stop_loss).toFixed(4)}</td>
-                            <td class="${pnlClass}">${t.pnl_unrealized.toFixed(2)}</td>
-                        </tr>`;
-                    }
-                } else {
-                    html = `<tr><td colspan="7" class="text-secondary py-4">No hay operaciones abiertas.</td></tr>`;
-                }
-                document.getElementById('ops').innerHTML = html;
-            } catch(e){
-                document.getElementById('ops').innerHTML = `<tr><td colspan="7" class="text-danger py-4">Error cargando datos</td></tr>`;
-            }
-        }
+        <div class="row g-3 mt-1">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                        <div>
+                            <h2 class="h5 mb-0">Operaciones abiertas</h2>
+                            <p class="text-muted small mb-0">Filtra por símbolo o revisa los últimos cambios en las posiciones activas</p>
+                        </div>
+                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
+                            <label for="symbolFilter" class="small text-muted text-uppercase">Filtrar por símbolo</label>
+                            <input type="search" id="symbolFilter" class="form-control form-control-sm" placeholder="Ej: BTCUSDT">
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle mb-0 text-center">
+                            <thead>
+                                <tr>
+                                    <th>Símbolo</th>
+                                    <th>Side</th>
+                                    <th>Cantidad</th>
+                                    <th>Entrada</th>
+                                    <th>Precio Actual</th>
+                                    <th>Take Profit</th>
+                                    <th>Stop Loss</th>
+                                    <th>PnL</th>
+                                    <th>Abierta</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tradesTableBody">
+                                <tr>
+                                    <td colspan="9" class="text-muted py-4">Sin operaciones abiertas.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-        async function loadLiquidity() {
-            try {
-                let resp = await fetch('/api/liquidity');
-                let data = await resp.json();
-                let html = '<table class="table table-bordered text-center"><tr><th>Símbolo</th><th>Bid</th><th>Ask</th></tr>';
-                for (const sym in data) {
-                    const entry = data[sym];
-                    const bid = entry.bids && entry.bids.length > 0 ? entry.bids[0][0] : "N/A";
-                    const ask = entry.asks && entry.asks.length > 0 ? entry.asks[0][0] : "N/A";
-                    html += `<tr><td>${sym}</td><td>${bid}</td><td>${ask}</td></tr>`;
-                }
-                html += '</table>';
-                document.getElementById('liquidityContainer').innerHTML = html;
-            } catch(e) {
-                document.getElementById('liquidityContainer').innerHTML = '<div class="text-danger">Error al cargar liquidez</div>';
-            }
-        }
+        <div class="row g-3 mt-1">
+            <div class="col-12 col-xl-6">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="h5 mb-0">Libro de órdenes</h2>
+                        <span class="badge bg-dark-subtle text-dark">Actualizado en vivo</span>
+                    </div>
+                    <div class="card-body" id="liquidityContainer">
+                        <div class="text-muted text-center">Esperando datos de liquidez…</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-xl-6">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="h5 mb-0">Historial reciente</h2>
+                        <span class="badge bg-info text-dark">Últimas 15 operaciones</span>
+                    </div>
+                    <div class="card-body">
+                        <div id="historyList" class="history-list">
+                            <div class="text-center text-muted">Sin operaciones cerradas recientes.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
 
-        document.getElementById('btnTrades').addEventListener('click', loadTrades);
-        document.getElementById('btnLiquidity').addEventListener('click', loadLiquidity);
-        setInterval(() => {
-            loadTrades();
-            loadLiquidity();
-        }, REFRESH_INTERVAL * 1000);
-    </script>
+    <footer class="footer py-4 text-center">
+        &copy; {{ current_year }} Trading Bot Dashboard · Diseñado con Flask &amp; Bootstrap
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+    <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
 </body>
 </html>

--- a/trading_bot/webapp.py
+++ b/trading_bot/webapp.py
@@ -1,27 +1,35 @@
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
 try:
-    from flask import Flask, render_template, jsonify
+    from flask import Flask, render_template, jsonify, request
 except ImportError:  # Flask not installed
     Flask = None
 
 from trading_bot.trade_manager import all_open_trades
 from trading_bot import liquidity_ws, data
+from trading_bot.history import HISTORY_FILE, FIELDS as HISTORY_FIELDS
 
 if Flask:
     app = Flask(__name__)
 
-    @app.route("/")
-    def index():
-        return render_template("index.html")
+    def _coerce_float(value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
 
-    @app.route("/api/trades")
-    def api_trades():
-        """Return open trades with current price and unrealized PnL."""
-        trades = []
-        for t in all_open_trades():
-            sym = t.get("symbol")
-            entry = float(t.get("entry_price", 0))
-            qty = float(t.get("quantity", 0))
-            side = t.get("side", "BUY").upper()
+    def _trades_with_metrics() -> list[dict[str, Any]]:
+        trades: list[dict[str, Any]] = []
+        for trade in all_open_trades():
+            sym = trade.get("symbol")
+            entry = _coerce_float(trade.get("entry_price", 0))
+            qty = _coerce_float(trade.get("quantity", 0))
+            side = str(trade.get("side", "BUY")).upper()
             current_price = data.get_current_price_ticker(sym)
             if not current_price:
                 current_price = entry
@@ -30,11 +38,116 @@ if Flask:
                 if side == "BUY"
                 else (entry - current_price) * qty
             )
-            row = t.copy()
+            row = dict(trade)
+            row["entry_price"] = entry
+            row["quantity"] = qty
             row["current_price"] = current_price
             row["pnl_unrealized"] = pnl
+            row["notional_value"] = abs(entry * qty)
             trades.append(row)
-        return jsonify(trades)
+        return trades
+
+    @app.route("/")
+    def index():
+        return render_template("index.html", current_year=datetime.utcnow().year)
+
+    @app.route("/api/trades")
+    def api_trades():
+        """Return open trades with current price and unrealized PnL."""
+        return jsonify(_trades_with_metrics())
+
+    @app.route("/api/summary")
+    def api_summary():
+        """Aggregate metrics that power the dashboard widgets."""
+        trades = _trades_with_metrics()
+        total_positions = len(trades)
+        total_exposure = sum(abs(t["quantity"]) for t in trades)
+        gross_notional = sum(t["notional_value"] for t in trades)
+        unrealized_pnl = sum(t["pnl_unrealized"] for t in trades)
+        winners = sum(1 for t in trades if t["pnl_unrealized"] > 0)
+        losers = sum(1 for t in trades if t["pnl_unrealized"] < 0)
+
+        per_symbol: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {
+                "symbol": "",
+                "positions": 0,
+                "exposure": 0.0,
+                "unrealized_pnl": 0.0,
+                "notional_value": 0.0,
+            }
+        )
+
+        for trade in trades:
+            sym = str(trade.get("symbol", "")).upper()
+            entry = per_symbol[sym]
+            entry["symbol"] = sym
+            entry["positions"] += 1
+            entry["exposure"] += abs(trade["quantity"])
+            entry["unrealized_pnl"] += trade["pnl_unrealized"]
+            entry["notional_value"] += trade["notional_value"]
+
+        per_symbol_list = sorted(
+            per_symbol.values(),
+            key=lambda item: item["notional_value"],
+            reverse=True,
+        )
+
+        win_rate = 0.0
+        deciding = winners + losers
+        if deciding:
+            win_rate = winners / deciding
+
+        payload = {
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "total_positions": total_positions,
+            "total_exposure": total_exposure,
+            "gross_notional": gross_notional,
+            "unrealized_pnl": unrealized_pnl,
+            "winning_positions": winners,
+            "losing_positions": losers,
+            "win_rate": win_rate,
+            "per_symbol": per_symbol_list,
+        }
+        return jsonify(payload)
+
+    @app.route("/api/history")
+    def api_history():
+        """Return the latest closed trades from the CSV history file."""
+        try:
+            limit = int(request.args.get("limit", 20))
+        except (TypeError, ValueError):
+            limit = 20
+        limit = max(1, min(limit, 200))
+
+        rows: list[dict[str, Any]] = []
+        if HISTORY_FILE.exists():
+            with HISTORY_FILE.open(newline="") as handle:
+                reader = list(csv.DictReader(handle, fieldnames=HISTORY_FIELDS))
+            if reader:
+                # The first row might be the header if DictReader didn't skip it
+                if reader[0] and reader[0][HISTORY_FIELDS[0]] == HISTORY_FIELDS[0]:
+                    reader = reader[1:]
+                rows = reader[-limit:]
+
+        formatted_rows: list[dict[str, Any]] = []
+        for row in reversed(rows):
+            formatted_rows.append(
+                {
+                    key: row.get(key, "")
+                    for key in (
+                        "symbol",
+                        "side",
+                        "quantity",
+                        "entry_price",
+                        "exit_price",
+                        "profit",
+                        "open_time",
+                        "close_time",
+                    )
+                }
+            )
+
+        return jsonify(formatted_rows)
 
     @app.route("/api/liquidity")
     def api_liquidity():


### PR DESCRIPTION
## Summary
- refresh the Flask dashboard with a responsive Bootstrap layout, new KPI cards, symbol breakdowns, and a live PnL chart powered by Chart.js
- add summary and history API endpoints plus shared metric helpers so the UI can display aggregated trading data
- introduce modular CSS/JS assets for the dashboard and extend tests to cover the new API responses

## Testing
- PYTHONPATH=. pytest tests/test_webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1f977ee08333af2d23e7395e08d2