### PR TITLE
Ensure dry run mode skips order submission in execution paths

### DIFF
--- a/trading_bot/execution.py
+++ b/trading_bot/execution.py
@@ -300,9 +300,9 @@ def open_position(
     side_lower = side_normalized.lower()
 
     dry_mode = (
-        config.BOT_MODE == "shadow"
+        config.DRY_RUN
+        or config.BOT_MODE == "shadow"
         or not config.ENABLE_TRADING
-        or (config.DRY_RUN and not config.ENABLE_TRADING)
     )
     if dry_mode:
         mock_id = f"MOCK-{normalize_symbol(symbol)}-{int(time.time() * 1000)}"
@@ -414,9 +414,9 @@ def close_position(
     side_lower = side.lower()
     execution_side = "buy" if side_lower in {"close_short", "buy"} else "sell"
     dry_mode = (
-        config.BOT_MODE == "shadow"
+        config.DRY_RUN
+        or config.BOT_MODE == "shadow"
         or not config.ENABLE_TRADING
-        or (config.DRY_RUN and not config.ENABLE_TRADING)
     )
     if dry_mode:
         mock_id = f"MOCK-CLOSE-{normalize_symbol(symbol)}-{int(time.time() * 1000)}"


### PR DESCRIPTION
## Summary
- ensure the execution dry-run predicate short-circuits whenever DRY_RUN is enabled
- apply the restored dry-run guard to both open and close position helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce6fd49b08333a98a502570c79041