### PR TITLE
Handle uppercase DEFAULT_EXCHANGE in permissions checks

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import pytest
 
 from trading_bot import permissions, config
@@ -24,6 +29,16 @@ def test_mock_exchange_bypasses_live_checks(monkeypatch):
     monkeypatch.setattr(config, "TRADING_MODE", "live", raising=False)
     monkeypatch.setattr(config, "ALLOW_LIVE_TRADING", False, raising=False)
     permissions.ensure_open_trade_allowed(MockExchange())
+
+
+def test_missing_credentials_with_uppercase_default_exchange(monkeypatch):
+    monkeypatch.setattr(config, "DEFAULT_EXCHANGE", "BINANCE", raising=False)
+    monkeypatch.setattr(config, "BINANCE_API_KEY", "", raising=False)
+    monkeypatch.setattr(config, "BINANCE_API_SECRET", "", raising=False)
+
+    missing = permissions._missing_credentials()
+
+    assert missing == ["BINANCE_API_KEY", "BINANCE_API_SECRET"]
 
 
 def test_token_permissions(tmp_path, monkeypatch):

--- a/trading_bot/permissions.py
+++ b/trading_bot/permissions.py
@@ -33,7 +33,8 @@ def _is_paper_trading(exchange: Optional[object]) -> bool:
 def _missing_credentials() -> list[str]:
     """Return a list of missing API credential names."""
     required: list[tuple[str, str]] = []
-    if config.DEFAULT_EXCHANGE == "bitget":
+    exchange = (config.DEFAULT_EXCHANGE or "").strip().lower()
+    if exchange == "bitget":
         required.extend(
             [
                 ("BITGET_API_KEY", config.BITGET_API_KEY),
@@ -41,14 +42,14 @@ def _missing_credentials() -> list[str]:
                 ("BITGET_PASSPHRASE", config.BITGET_PASSPHRASE),
             ]
         )
-    elif config.DEFAULT_EXCHANGE == "binance":
+    elif exchange == "binance":
         required.extend(
             [
                 ("BINANCE_API_KEY", config.BINANCE_API_KEY),
                 ("BINANCE_API_SECRET", config.BINANCE_API_SECRET),
             ]
         )
-    elif config.DEFAULT_EXCHANGE == "mexc":
+    elif exchange == "mexc":
         required.extend(
             [
                 ("MEXC_API_KEY", config.MEXC_API_KEY),


### PR DESCRIPTION
## Summary
- normalize the DEFAULT_EXCHANGE handling in the permissions helper so uppercase values still trigger credential checks
- extend the permissions test suite to cover uppercase exchange names while preserving existing credential validation behavior

## Testing
- pytest tests/test_permissions.py

------
https://chatgpt.com/codex/tasks/task_b_68dd8fac771c8320a465dafb850442bb