### PR TITLE
Update Bitget websocket domain

### DIFF
--- a/trading_bot/liquidity_ws.py
+++ b/trading_bot/liquidity_ws.py
@@ -219,7 +219,7 @@ class DualExchangeLiquidityStream:
 
     async def _bitget_listener(self, symbols: Iterable[str]):
         subs = [{"op": "subscribe", "args": [f"books{DEPTH}:{format_bitget_stream_symbol(s)}"]} for s in symbols]
-        url = "wss://ws.bitget.com/mix/v1/stream"
+        url = "wss://ws.bitgetapi.com/mix/v1/stream"
         backoff = config.WS_BACKOFF_MIN_S
         while not self._stop_event.is_set():
             try:


### PR DESCRIPTION
## Summary
- point the Bitget liquidity websocket client at the updated bitgetapi.com endpoint to avoid SSL hostname mismatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de3b64f6488320a01ab49caf6b164b