### PR TITLE
Modernize dashboard experience with integrated services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,10 @@ venv.bak/
 
 # pyre type checker
 .pyre/
+
+# Local run artifacts
+exports/
+open_trades.json
+closed_trades.json
+trade_history.csv
+trading_bot/auto_trade_state.json

--- a/trading_bot/static/css/dashboard.css
+++ b/trading_bot/static/css/dashboard.css
@@ -20,6 +20,12 @@
     --shadow-strong: rgba(0, 0, 0, 0.5);
 }
 
+:root[data-theme='pastel'] {
+    color-scheme: light;
+    --surface-elevated: rgba(255, 255, 255, 0.95);
+    --shadow-strong: rgba(168, 85, 247, 0.25);
+}
+
 body {
     background: var(--background);
     min-height: 100vh;
@@ -62,6 +68,15 @@ body,
     backdrop-filter: blur(10px);
 }
 
+.navbar .navbar-toggler {
+    border: none;
+    background-color: rgba(255, 255, 255, 0.25);
+}
+
+.navbar .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,255,255,0.85)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
+}
+
 .navbar-brand {
     font-weight: 700;
     color: #fff;
@@ -73,11 +88,53 @@ body,
     color: inherit;
 }
 
+.section-nav .nav-link {
+    color: rgba(255, 255, 255, 0.75);
+    font-weight: 500;
+    border-radius: 999px;
+    padding-inline: 1rem;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.section-nav .nav-link:hover,
+.section-nav .nav-link:focus {
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+.section-nav .nav-link.active {
+    color: #2c3e50;
+    background-color: #fff;
+}
+
 .navbar .badge,
 .navbar .btn {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+}
+
+.navbar .btn-outline-light {
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.65);
+    background: transparent;
+}
+
+.navbar .btn-outline-light:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.app-section {
+    display: none;
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.app-section.is-active {
+    display: block;
+    opacity: 1;
+    transform: translateY(0);
 }
 
 main.container-fluid {
@@ -223,6 +280,11 @@ main.container-fluid {
 
 :root[data-theme='dark'] .btn-ghost:hover {
     background: rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme='pastel'] .btn-ghost {
+    background: rgba(255, 255, 255, 0.6);
+    border-color: rgba(168, 85, 247, 0.25);
 }
 
 .btn i {
@@ -452,6 +514,103 @@ td.price-down {
     padding: 0.9rem 1.2rem;
     color: var(--text-primary);
     box-shadow: 6px 6px 12px var(--shadow), -6px -6px 12px rgba(255, 255, 255, 0.6);
+}
+
+.history-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px var(--shadow);
+}
+
+.widget-hidden {
+    display: none !important;
+}
+
+#analyticsStatus {
+    min-height: 1.5rem;
+}
+
+#analyticsTradesTable tbody tr {
+    transition: transform 0.2s ease, box-shadow 0.3s ease;
+}
+
+.analytics-preferences dt {
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+}
+
+.analytics-preferences dd {
+    margin-bottom: 1rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.ai-chat-window {
+    background: var(--surface);
+    border-radius: 16px;
+    border: 1px solid var(--border-subtle);
+    padding: 1rem;
+    height: 320px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.chat-message {
+    padding: 0.75rem 1rem;
+    border-radius: 16px;
+    max-width: 90%;
+    box-shadow: 0 6px 12px var(--shadow);
+    line-height: 1.4;
+}
+
+.chat-message--user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, var(--accent-secondary), var(--accent-primary));
+    color: #fff;
+}
+
+.chat-message--assistant {
+    align-self: flex-start;
+    background: var(--surface-elevated);
+    color: var(--text-primary);
+}
+
+.chat-message--system {
+    align-self: center;
+    background: transparent;
+    color: var(--text-secondary);
+    box-shadow: none;
+}
+
+.ai-chat-form textarea {
+    resize: vertical;
+}
+
+.ai-report-output {
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 1rem;
+    border: 1px solid var(--border-subtle);
+    min-height: 180px;
+    white-space: pre-wrap;
+}
+
+[data-open-service] {
+    justify-content: center;
+}
+
+@media (max-width: 991.98px) {
+    .section-nav .nav-link {
+        margin-bottom: 0.5rem;
+    }
+
+    .app-section {
+        transform: none;
+    }
 }
 
 .history-item .side-buy {

--- a/trading_bot/templates/index.html
+++ b/trading_bot/templates/index.html
@@ -25,10 +25,18 @@
       --border-subtle: rgba(0, 0, 0, 0.05);
     }
 
-    body {
-      font-family: 'Poppins', 'Segoe UI', sans-serif;
-      background: var(--background);
-      color: var(--text-primary);
+    :root[data-theme="pastel"] {
+      --background: #f7f1ff;
+      --surface: rgba(255, 255, 255, 0.8);
+      --surface-strong: rgba(255, 255, 255, 0.95);
+      --surface-elevated: rgba(255, 255, 255, 0.95);
+      --accent-primary: #a855f7;
+      --accent-secondary: #f472b6;
+      --accent-tertiary: #60a5fa;
+      --text-primary: #4c1d95;
+      --text-secondary: rgba(124, 58, 237, 0.6);
+      --shadow: rgba(168, 85, 247, 0.2);
+      --border-subtle: rgba(168, 85, 247, 0.15);
     }
     </style>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -38,24 +46,39 @@
 <body>
     <nav class="navbar navbar-expand-lg">
         <div class="container-fluid px-4">
-            <a class="navbar-brand d-flex align-items-center gap-2" href="#">
+            <a class="navbar-brand d-flex align-items-center gap-2" href="#" data-section-target="dashboard">
                 <i class="bi bi-robot"></i>
                 <span>Patatabot</span>
             </a>
-            <div class="d-flex align-items-center gap-3 ms-auto">
-                <span class="badge d-none" id="modeBadge" aria-live="polite">Demo</span>
-                <span class="badge badge-status" id="connectionStatus">Sincronizando…</span>
-                <button class="btn btn-sm btn-secondary" id="toggleTradeBtn" type="button">
-                    <i class="bi bi-pause-circle"></i>
-                    Pausar bot
-                </button>
-                <button class="btn btn-sm btn-primary" id="refreshTradesBtn" type="button">
-                    <i class="bi bi-arrow-repeat"></i>
-                    Actualizar ahora
-                </button>
-                <button class="btn btn-sm btn-ghost" id="themeToggleBtn" type="button" aria-pressed="false" aria-label="Cambiar tema">
-                    <i class="bi bi-moon-stars"></i>
-                </button>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Alternar navegación">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNavbar">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0 section-nav">
+                    <li class="nav-item"><a class="nav-link active" href="#dashboard" data-section-target="dashboard">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#analytics" data-section-target="analytics">Analítica</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#ai-assistant" data-section-target="ai-assistant">Asistente IA</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#services" data-section-target="services">Servicios</a></li>
+                </ul>
+                <div class="d-flex align-items-center gap-3 ms-lg-auto">
+                    <span class="badge d-none" id="modeBadge" aria-live="polite">Demo</span>
+                    <span class="badge badge-status" id="connectionStatus">Sincronizando…</span>
+                    <button class="btn btn-sm btn-outline-light" id="openConfigBtn" type="button">
+                        <i class="bi bi-sliders"></i>
+                        Personalizar
+                    </button>
+                    <button class="btn btn-sm btn-secondary" id="toggleTradeBtn" type="button">
+                        <i class="bi bi-pause-circle"></i>
+                        Pausar bot
+                    </button>
+                    <button class="btn btn-sm btn-primary" id="refreshTradesBtn" type="button">
+                        <i class="bi bi-arrow-repeat"></i>
+                        Actualizar
+                    </button>
+                    <button class="btn btn-sm btn-ghost" id="themeToggleBtn" type="button" aria-pressed="false" aria-label="Cambiar tema">
+                        <i class="bi bi-moon-stars"></i>
+                    </button>
+                </div>
             </div>
         </div>
     </nav>
@@ -63,169 +86,325 @@
     <main class="container-fluid py-4 px-4 px-xl-5">
         <div id="globalAlerts" class="mb-3"></div>
 
-        <div class="row g-3">
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">Posiciones abiertas</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricPositions">0</div>
-                        <div class="metric-delta text-muted">Número total de operaciones activas</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">PnL no realizado</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricPnL">0.00</div>
-                        <div class="metric-delta text-muted">Actualizado en tiempo real</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">Capital invertido</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricExposure">0.00</div>
-                        <div class="metric-delta text-muted">Suma de USDT en riesgo</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">Win rate</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricWinRate">0%</div>
-                        <div class="metric-delta text-muted">Operaciones en verde vs. en rojo</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="row g-3 mt-1">
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">Saldo realizado</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricRealizedBalance">0.00</div>
-                        <div class="metric-delta text-muted">Capital recuperado de operaciones cerradas</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12 col-md-6 col-xl-3">
-                <div class="card metric-card h-100">
-                    <div class="card-body">
-                        <div class="metric-label">PnL realizado</div>
-                        <div class="metric-value skeleton" data-skeleton id="metricRealizedPnL">0.00</div>
-                        <div class="metric-delta text-muted">Ganancias y pérdidas materializadas</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div id="dashboardGrid" class="row g-3 mt-1" aria-live="polite">
-            <div class="col-12 col-xl-8" data-id="pnlCard">
-                <div class="card h-100 collapsible-card" data-card-id="pnlCard">
-                    <div class="card-header d-flex align-items-center justify-content-between">
-                        <div>
-                            <h2 class="h5 mb-0">Evolución del PnL total</h2>
-                            <p class="text-muted mb-0 small">Incluye PnL realizado y no realizado</p>
+        <section class="app-section is-active" id="dashboardSection" data-section="dashboard">
+            <div class="row g-3" data-widget="metrics_primary">
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">Posiciones abiertas</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricPositions">0</div>
+                            <div class="metric-delta text-muted">Número total de operaciones activas</div>
                         </div>
-                        <div class="d-flex align-items-center gap-2">
-                            <small class="text-muted" id="lastUpdated">Sin datos</small>
-                            <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="pnlCard" aria-expanded="true" aria-controls="pnlCardContent" aria-label="Colapsar gráfico de PnL">
+                    </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">PnL no realizado</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricPnL">0.00</div>
+                            <div class="metric-delta text-muted">Actualizado en tiempo real</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">Capital invertido</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricExposure">0.00</div>
+                            <div class="metric-delta text-muted">Suma de USDT en riesgo</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">Win rate</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricWinRate">0%</div>
+                            <div class="metric-delta text-muted">Operaciones en verde vs. en rojo</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row g-3 mt-1" data-widget="metrics_secondary">
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">Saldo realizado</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricRealizedBalance">0.00</div>
+                            <div class="metric-delta text-muted">Capital recuperado de operaciones cerradas</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    <div class="card metric-card h-100">
+                        <div class="card-body">
+                            <div class="metric-label">PnL realizado</div>
+                            <div class="metric-value skeleton" data-skeleton id="metricRealizedPnL">0.00</div>
+                            <div class="metric-delta text-muted">Ganancias y pérdidas materializadas</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="dashboardGrid" class="row g-3 mt-1" aria-live="polite">
+                <div class="col-12 col-xl-8" data-id="pnlCard" data-widget="pnl">
+                    <div class="card h-100 collapsible-card" data-card-id="pnlCard">
+                        <div class="card-header d-flex align-items-center justify-content-between">
+                            <div>
+                                <h2 class="h5 mb-0">Evolución del PnL total</h2>
+                                <p class="text-muted mb-0 small">Incluye PnL realizado y no realizado</p>
+                            </div>
+                            <div class="d-flex align-items-center gap-2">
+                                <small class="text-muted" id="lastUpdated">Sin datos</small>
+                                <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="pnlCard" aria-expanded="true" aria-controls="pnlCardContent" aria-label="Colapsar gráfico de PnL">
+                                    <i class="bi bi-arrows-collapse"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="collapsible-content" id="pnlCardContent">
+                            <div class="card-body" style="height: 320px;">
+                                <canvas id="pnlChart" aria-label="Gráfico de PnL"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-4" data-id="symbolCard" data-widget="symbols">
+                    <div class="card h-100 collapsible-card" data-card-id="symbolCard">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Capital invertido por símbolo</h2>
+                            <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="symbolCard" aria-expanded="true" aria-controls="symbolCardContent" aria-label="Colapsar resumen por símbolo">
                                 <i class="bi bi-arrows-collapse"></i>
                             </button>
                         </div>
-                    </div>
-                    <div class="collapsible-content" id="pnlCardContent">
-                        <div class="card-body" style="height: 320px;">
-                            <canvas id="pnlChart" aria-label="Gráfico de PnL"></canvas>
+                        <div class="collapsible-content" id="symbolCardContent">
+                            <div class="card-body">
+                                <ul class="list-group list-group-flush symbol-breakdown" id="symbolBreakdown" data-skeleton>
+                                    <li class="list-group-item skeleton">Sin posiciones abiertas.</li>
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="col-12 col-xl-4" data-id="symbolCard">
-                <div class="card h-100 collapsible-card" data-card-id="symbolCard">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h2 class="h5 mb-0">Capital invertido por símbolo</h2>
-                        <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="symbolCard" aria-expanded="true" aria-controls="symbolCardContent" aria-label="Colapsar resumen por símbolo">
-                            <i class="bi bi-arrows-collapse"></i>
-                        </button>
-                    </div>
-                    <div class="collapsible-content" id="symbolCardContent">
-                        <div class="card-body">
-                            <ul class="list-group list-group-flush symbol-breakdown" id="symbolBreakdown" data-skeleton>
-                                <li class="list-group-item skeleton">Sin posiciones abiertas.</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12" data-id="tradesCard">
-                <div class="card collapsible-card" data-card-id="tradesCard">
-                    <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
-                        <div>
-                            <h2 class="h5 mb-0">Operaciones abiertas</h2>
-                            <p class="text-muted small mb-0">Filtra por símbolo o revisa los últimos cambios en las posiciones activas</p>
-                        </div>
-                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
-                            <label for="symbolFilter" class="small text-muted text-uppercase">Filtrar por símbolo</label>
-                            <input type="search" id="symbolFilter" class="form-control form-control-sm" placeholder="Ej: BTCUSDT">
-                        </div>
-                        <button class="btn btn-sm btn-ghost card-toggle ms-lg-2" type="button" data-card-toggle="tradesCard" aria-expanded="true" aria-controls="tradesCardContent" aria-label="Colapsar tabla de operaciones">
-                            <i class="bi bi-arrows-collapse"></i>
-                        </button>
-                    </div>
-                    <div class="collapsible-content" id="tradesCardContent">
-                        <div class="table-responsive">
-                            <table class="table table-hover align-middle mb-0 text-center" id="tradesTable" data-skeleton>
-                                <thead>
-                                    <tr>
-                                        <th>Símbolo</th>
-                                        <th>Side</th>
-                                        <th>Cantidad</th>
-                                        <th>Entrada</th>
-                                        <th>Precio Actual</th>
-                                        <th>Take Profit</th>
-                                        <th>Stop Loss</th>
-                                        <th>PnL</th>
-                                        <th>PnL Realizado</th>
-                                        <th>Abierta</th>
-                                        <th>Acciones</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="tradesTableBody">
-                                    <tr class="skeleton-row">
-                                        <td colspan="11" class="text-muted py-4 skeleton">Sin operaciones abiertas.</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12" data-id="historyCard">
-                <div class="card h-100 collapsible-card" data-card-id="historyCard">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h2 class="h5 mb-0">Historial reciente</h2>
-                        <div class="d-flex align-items-center gap-2">
-                            <span class="badge bg-info text-dark">Últimas 50 operaciones</span>
-                            <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="historyCard" aria-expanded="true" aria-controls="historyCardContent" aria-label="Colapsar historial reciente">
+                <div class="col-12" data-id="tradesCard" data-widget="trades">
+                    <div class="card collapsible-card" data-card-id="tradesCard">
+                        <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                            <div>
+                                <h2 class="h5 mb-0">Operaciones abiertas</h2>
+                                <p class="text-muted small mb-0">Filtra por símbolo o revisa los últimos cambios en las posiciones activas</p>
+                            </div>
+                            <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
+                                <label for="symbolFilter" class="small text-muted text-uppercase">Filtrar por símbolo</label>
+                                <input type="search" id="symbolFilter" class="form-control form-control-sm" placeholder="Ej: BTCUSDT">
+                            </div>
+                            <button class="btn btn-sm btn-ghost card-toggle ms-lg-2" type="button" data-card-toggle="tradesCard" aria-expanded="true" aria-controls="tradesCardContent" aria-label="Colapsar tabla de operaciones">
                                 <i class="bi bi-arrows-collapse"></i>
                             </button>
                         </div>
+                        <div class="collapsible-content" id="tradesCardContent">
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle mb-0 text-center" id="tradesTable" data-skeleton>
+                                    <thead>
+                                        <tr>
+                                            <th>Símbolo</th>
+                                            <th>Side</th>
+                                            <th>Cantidad</th>
+                                            <th>Entrada</th>
+                                            <th>Precio Actual</th>
+                                            <th>Take Profit</th>
+                                            <th>Stop Loss</th>
+                                            <th>PnL</th>
+                                            <th>PnL Realizado</th>
+                                            <th>Abierta</th>
+                                            <th>Acciones</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="tradesTableBody">
+                                        <tr class="skeleton-row">
+                                            <td colspan="11" class="text-muted py-4 skeleton">Sin operaciones abiertas.</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
                     </div>
-                    <div class="collapsible-content" id="historyCardContent">
-                        <div class="card-body">
-                            <div id="historyList" class="history-list" data-skeleton>
-                                <div class="text-center text-muted skeleton">Sin operaciones cerradas recientes.</div>
+                </div>
+                <div class="col-12" data-id="historyCard" data-widget="history">
+                    <div class="card h-100 collapsible-card" data-card-id="historyCard">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Historial reciente</h2>
+                            <div class="d-flex align-items-center gap-2">
+                                <span class="badge bg-info text-dark">Últimas 50 operaciones</span>
+                                <button class="btn btn-sm btn-ghost card-toggle" type="button" data-card-toggle="historyCard" aria-expanded="true" aria-controls="historyCardContent" aria-label="Colapsar historial reciente">
+                                    <i class="bi bi-arrows-collapse"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="collapsible-content" id="historyCardContent">
+                            <div class="card-body">
+                                <div id="historyList" class="history-list" data-skeleton>
+                                    <div class="text-center text-muted skeleton">Sin operaciones cerradas recientes.</div>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
+
+        <section class="app-section d-none" id="analyticsSection" data-section="analytics">
+            <div class="row g-3">
+                <div class="col-12 col-xl-8">
+                    <div class="card h-100">
+                        <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                            <div>
+                                <h2 class="h5 mb-0">Consultas al motor analítico</h2>
+                                <p class="text-muted small mb-0">Datos servidos vía GraphQL desde el microservicio de analítica</p>
+                            </div>
+                            <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
+                                <input type="search" id="analyticsSymbolFilter" class="form-control form-control-sm" placeholder="Filtrar por símbolo (opcional)">
+                                <button class="btn btn-sm btn-primary" id="analyticsRefreshBtn" type="button">
+                                    <i class="bi bi-arrow-clockwise"></i> Actualizar
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body">
+                            <div id="analyticsStatus" class="text-muted small mb-3">Conecta con el gateway para obtener la información…</div>
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle text-center" id="analyticsTradesTable">
+                                    <thead>
+                                        <tr>
+                                            <th>Símbolo</th>
+                                            <th>Side</th>
+                                            <th>Cantidad</th>
+                                            <th>PnL</th>
+                                            <th>Apertura</th>
+                                            <th>Cierre</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="analyticsTradesBody">
+                                        <tr>
+                                            <td colspan="6" class="text-muted py-4">Sin datos todavía.</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-4">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Preferencias de usuario (GraphQL)</h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted small">Visualiza las preferencias almacenadas en el servicio de analítica.</p>
+                            <form id="analyticsSettingsForm" class="row gy-3">
+                                <div class="col-12">
+                                    <label for="analyticsUserId" class="form-label">ID de usuario</label>
+                                    <input type="number" min="1" class="form-control" id="analyticsUserId" value="1">
+                                </div>
+                                <div class="col-12">
+                                    <button class="btn btn-sm btn-secondary w-100" type="submit">
+                                        <i class="bi bi-search"></i> Consultar preferencias
+                                    </button>
+                                </div>
+                            </form>
+                            <dl class="analytics-preferences mt-4 mb-0" id="analyticsPreferences">
+                                <dt>Idioma</dt>
+                                <dd data-field="locale">—</dd>
+                                <dt>Tema preferido</dt>
+                                <dd data-field="theme">—</dd>
+                                <dt>Riesgo máximo</dt>
+                                <dd data-field="max_risk">—</dd>
+                                <dt>Notificaciones</dt>
+                                <dd data-field="notifications_enabled">—</dd>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="app-section d-none" id="aiAssistantSection" data-section="ai-assistant">
+            <div class="row g-3">
+                <div class="col-12 col-xl-7">
+                    <div class="card h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Asistente IA</h2>
+                            <span class="badge bg-light text-dark" id="aiStatus">Listo</span>
+                        </div>
+                        <div class="card-body d-flex flex-column">
+                            <div class="ai-chat-window mb-3" id="aiChatMessages" aria-live="polite">
+                                <div class="chat-message chat-message--system">¿En qué puedo ayudarte hoy?</div>
+                            </div>
+                            <form id="aiChatForm" class="ai-chat-form mt-auto">
+                                <label for="aiMessage" class="form-label visually-hidden">Mensaje</label>
+                                <textarea id="aiMessage" class="form-control" rows="3" placeholder="Pregunta algo al asistente…"></textarea>
+                                <div class="d-flex justify-content-end gap-2 mt-2">
+                                    <button class="btn btn-ghost" type="reset">Limpiar</button>
+                                    <button class="btn btn-primary" type="submit">
+                                        <i class="bi bi-send"></i> Enviar
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-5">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Generar informe rápido</h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted small">Envía las métricas actuales al asistente para recibir un resumen ejecutivo.</p>
+                            <button class="btn btn-tertiary w-100 mb-3" id="aiQuickReportBtn" type="button">
+                                <i class="bi bi-robot"></i> Pedir informe automático
+                            </button>
+                            <div class="ai-report-output" id="aiReportOutput">Aún no has solicitado ningún informe.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="app-section d-none" id="servicesSection" data-section="services">
+            <div class="row g-3">
+                <div class="col-12 col-xl-6">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Servicios conectados</h2>
+                        </div>
+                        <div class="card-body d-flex flex-column gap-3">
+                            <button class="btn btn-primary" type="button" data-open-service="orders">
+                                <i class="bi bi-box-arrow-up-right"></i> Abrir órdenes del motor de trading
+                            </button>
+                            <button class="btn btn-secondary" type="button" data-open-service="docs">
+                                <i class="bi bi-journal-text"></i> Documentación del gateway
+                            </button>
+                            <button class="btn btn-tertiary" type="button" data-open-service="analytics">
+                                <i class="bi bi-graph-up"></i> Consola GraphQL analítica
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-6">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Consejos de personalización</h2>
+                        </div>
+                        <div class="card-body">
+                            <ul class="list-unstyled mb-0 text-muted">
+                                <li class="mb-2"><i class="bi bi-arrows-move"></i> Arrastra las tarjetas del dashboard para reordenarlas.</li>
+                                <li class="mb-2"><i class="bi bi-magic"></i> Cambia de tema con el botón de la barra superior.</li>
+                                <li class="mb-2"><i class="bi bi-hourglass"></i> Configura el intervalo de refresco desde el panel de personalización.</li>
+                                <li><i class="bi bi-layout-three-columns"></i> Activa o desactiva widgets según tus necesidades.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer class="footer py-4 text-center">
@@ -256,6 +435,77 @@
         </div>
     </div>
 
+    <div class="modal fade" id="dashboardSettingsModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Personalizar dashboard</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <form id="dashboardSettingsForm">
+                    <div class="modal-body">
+                        <div class="row g-4">
+                            <div class="col-12 col-lg-6">
+                                <h6 class="text-uppercase text-muted small">Widgets visibles</h6>
+                                <div class="list-group" id="widgetList">
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Métricas principales</span>
+                                        <input class="form-check-input" type="checkbox" value="metrics_primary" checked>
+                                    </label>
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Métricas complementarias</span>
+                                        <input class="form-check-input" type="checkbox" value="metrics_secondary" checked>
+                                    </label>
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Gráfico PnL</span>
+                                        <input class="form-check-input" type="checkbox" value="pnl" checked>
+                                    </label>
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Resumen por símbolo</span>
+                                        <input class="form-check-input" type="checkbox" value="symbols" checked>
+                                    </label>
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Operaciones abiertas</span>
+                                        <input class="form-check-input" type="checkbox" value="trades" checked>
+                                    </label>
+                                    <label class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>Historial</span>
+                                        <input class="form-check-input" type="checkbox" value="history" checked>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6">
+                                <h6 class="text-uppercase text-muted small">Preferencias</h6>
+                                <div class="mb-3">
+                                    <label for="refreshIntervalSelect" class="form-label">Intervalo de refresco automático</label>
+                                    <select id="refreshIntervalSelect" class="form-select">
+                                        <option value="5000">Cada 5 segundos</option>
+                                        <option value="10000" selected>Cada 10 segundos</option>
+                                        <option value="30000">Cada 30 segundos</option>
+                                        <option value="60000">Cada minuto</option>
+                                    </select>
+                                </div>
+                                <div class="form-text">Puedes reordenar las tarjetas directamente en el dashboard arrastrándolas.</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-ghost" data-bs-dismiss="modal">Cerrar</button>
+                        <button type="submit" class="btn btn-primary">Guardar cambios</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        window.APP_CONFIG = {
+            apiBase: {{ api_base|tojson }},
+            graphqlUrl: {{ graphql_url|tojson }},
+            aiChatUrl: {{ ai_chat_url|tojson }},
+            aiReportUrl: {{ ai_report_url|tojson }}
+        };
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>

--- a/trading_bot/webapp.py
+++ b/trading_bot/webapp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import os
 import threading
 from collections import defaultdict
 from datetime import datetime
@@ -178,7 +179,17 @@ if Flask:
 
     @app.route("/")
     def index():
-        return render_template("index.html", current_year=datetime.utcnow().year)
+        gateway_base = os.getenv("GATEWAY_BASE_URL", "http://localhost:8080")
+        analytics_url = os.getenv("ANALYTICS_GRAPHQL_URL") or f"{gateway_base.rstrip('/')}/graphql"
+        ai_base = os.getenv("AI_GATEWAY_URL") or gateway_base.rstrip("/")
+        return render_template(
+            "index.html",
+            current_year=datetime.utcnow().year,
+            api_base=gateway_base.rstrip("/"),
+            graphql_url=analytics_url,
+            ai_chat_url=f"{ai_base}/ai/chat",
+            ai_report_url=f"{ai_base}/ai/report",
+        )
 
     @app.route("/manifest.json")
     def manifest():


### PR DESCRIPTION
## Summary
- Rebuild the dashboard template with navigation-driven sections for analytics, AI assistant, external services, and a personalization modal while wiring gateway configuration.
- Refresh the styling to support the new navigation, widget visibility controls, pastel theme accents, analytics tables, and AI chat presentation.
- Extend dashboard logic to cycle through three themes, persist widget and refresh preferences, fetch analytics via GraphQL, and integrate AI chat/report actions through the gateway.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e0f945cc548320933d4b95ce56dc05