### PR TITLE
Improve service worker cache management

### DIFF
--- a/trading_bot/static/service-worker.js
+++ b/trading_bot/static/service-worker.js
@@ -1,4 +1,11 @@
-const CACHE_NAME = 'bot-cache-v1';
+const cacheVersionSource =
+  self.registration?.installing?.scriptURL ||
+  self.registration?.active?.scriptURL ||
+  'bot-cache-v20240606';
+const CACHE_NAME = `bot-cache-${cacheVersionSource
+  .split('/')
+  .pop()
+  ?.replace(/[^a-z0-9_-]/gi, '-') ?? 'default'}`;
 const RESOURCES = ['/', '/static/css/dashboard.css', '/static/js/dashboard.js'];
 
 self.addEventListener('install', (event) => {
@@ -6,6 +13,20 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME).then((cache) => cache.addAll(RESOURCES)).catch((error) => {
       console.error('SW install error', error);
     }),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name)),
+      );
+      await self.clients.claim();
+    })(),
   );
 });
 


### PR DESCRIPTION
## Summary
- generate a cache name derived from the current service worker script so updates naturally bump the cache key
- add an activate handler that claims clients and prunes outdated caches to avoid serving stale assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2a1224c7883209f73188831030d49