### PR TITLE
Remove unused APP_CONFIG bootstrap block from dashboard template

### DIFF
--- a/trading_bot/templates/index.html
+++ b/trading_bot/templates/index.html
@@ -567,14 +567,6 @@
         </div>
     </div>
 
-    <script>
-        window.APP_CONFIG = {
-            apiBase: {{ api_base|tojson }},
-            graphqlUrl: {{ graphql_url|tojson }},
-            aiChatUrl: {{ ai_chat_url|tojson }},
-            aiReportUrl: {{ ai_report_url|tojson }}
-        };
-    </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- remove the unused window.APP_CONFIG bootstrap block from the dashboard template since configuration is sourced from data attributes

## Testing
- python - <<'PY'
from trading_bot.webapp import app
app.testing = True
client = app.test_client()
response = client.get('/')
print('status', response.status_code)
print('has_app_config', 'window.APP_CONFIG' in response.get_data(as_text=True))
PY


------
https://chatgpt.com/codex/tasks/task_b_68e2a35c5d3c83208882802e88e4776f