### PR TITLE
Define SECTION_IDS constant for dashboard navigation

### DIFF
--- a/trading_bot/static/js/dashboard.js
+++ b/trading_bot/static/js/dashboard.js
@@ -9,6 +9,7 @@ const THEME_STORAGE_KEY = 'dashboard:theme';
 const PREFERENCES_STORAGE_KEY = 'dashboard:preferences';
 const AVAILABLE_THEMES = ['light', 'dark', 'pastel'];
 const ORDERED_SECTIONS = ['dashboard', 'analytics', 'assistant', 'services'];
+const SECTION_IDS = ORDERED_SECTIONS;
 
 const themePalettes = {
   light: {


### PR DESCRIPTION
## Summary
- declare a SECTION_IDS constant alongside the existing ordered section list
- ensure switchSection relies on the shared constant to avoid DOMContentLoaded ReferenceError

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2af911b9083208492dcaae382acf3