### PR TITLE
Fix dashboard trading controls block syntax

### DIFF
--- a/trading_bot/static/js/dashboard.js
+++ b/trading_bot/static/js/dashboard.js
@@ -9,6 +9,7 @@ const THEME_STORAGE_KEY = 'dashboard:theme';
 const PREFERENCES_STORAGE_KEY = 'dashboard:preferences';
 const AVAILABLE_THEMES = ['light', 'dark', 'pastel'];
 const ORDERED_SECTIONS = ['dashboard', 'analytics', 'assistant', 'services'];
+const SECTION_IDS = [...ORDERED_SECTIONS];
 
 const themePalettes = {
   light: {
@@ -429,24 +430,32 @@ function getFirstEnabledSection() {
 
 function setActiveSection(sectionId, options = {}) {
   const { force = false } = options;
-  if (!force && !isSectionEnabled(sectionId)) {
+  const normalized = SECTION_IDS.includes(sectionId) ? sectionId : 'dashboard';
+  if (!force && !isSectionEnabled(normalized)) {
     return;
   }
-  state.activeSection = sectionId;
+  const previous = state.activeSection;
+  state.activeSection = normalized;
   document.querySelectorAll('.app-section').forEach((section) => {
     const id = section.dataset.section;
     const enabled = !section.classList.contains('section-hidden');
-    const isActive = enabled && id === sectionId;
+    const isActive = enabled && id === normalized;
     section.classList.toggle('active', isActive);
+    section.classList.toggle('is-active', isActive);
     section.classList.toggle('d-none', !isActive);
+    if (isActive) {
+      section.removeAttribute('hidden');
+    } else {
+      section.setAttribute('hidden', 'hidden');
+    }
   });
-  document.querySelectorAll('[data-section-target]').forEach((link) => {
-    const target = link.dataset.sectionTarget;
-    const enabled = isSectionEnabled(target);
-    const isActive = enabled && target === sectionId;
-    link.classList.toggle('active', isActive);
-    link.setAttribute('aria-current', isActive ? 'page' : 'false');
-  });
+  updateNavLinks(normalized);
+  if (normalized === 'analytics' && previous !== 'analytics') {
+    ensureAnalyticsData();
+  }
+  if (normalized === 'assistant' && previous !== 'assistant') {
+    focusAiInput();
+  }
 }
 
 function updateWidgetVisibility() {
@@ -692,6 +701,7 @@ function updateTradingControls(isActive) {
       const variant = isActive ? 'success' : 'warning';
       setStatus(label, variant);
     }
+  }
   if (toggleBtn) {
     toggleBtn.disabled = !state.connectionHealthy;
     toggleBtn.className = `btn btn-sm ${isActive ? 'btn-secondary' : 'btn-tertiary'}`;
@@ -699,7 +709,6 @@ function updateTradingControls(isActive) {
       ? '<i class="bi bi-pause-circle"></i> Pausar bot'
       : '<i class="bi bi-play-circle"></i> Reanudar bot';
   }
-}
 }
 
 function showAlert(message, variant = 'danger') {
@@ -1080,7 +1089,7 @@ function updateNavLinks(activeSection) {
 }
 
 function focusAiInput() {
-  const input = document.getElementById('aiMessage');
+  const input = document.getElementById('aiMessageInput');
   if (input) {
     window.requestAnimationFrame(() => {
       input.focus();
@@ -1089,26 +1098,7 @@ function focusAiInput() {
 }
 
 function switchSection(sectionId) {
-  const normalized = SECTION_IDS.includes(sectionId) ? sectionId : 'dashboard';
-  state.activeSection = normalized;
-  document.querySelectorAll('.app-section').forEach((section) => {
-    const isTarget = section.dataset.section === normalized;
-    section.classList.toggle('is-active', isTarget);
-    if (isTarget) {
-      section.classList.remove('d-none');
-      section.removeAttribute('hidden');
-    } else {
-      section.classList.add('d-none');
-      section.setAttribute('hidden', 'hidden');
-    }
-  });
-  updateNavLinks(normalized);
-  if (normalized === 'analytics') {
-    ensureAnalyticsData();
-  }
-  if (normalized === 'ai-assistant') {
-    focusAiInput();
-  }
+  setActiveSection(sectionId, { force: true });
 }
 
 function registerServiceWorker() {


### PR DESCRIPTION
## Summary
- normalize section switching to use setActiveSection so hidden attributes and navigation state stay in sync
- ensure the assistant section focuses the correct input and reuse the shared section id list safely
- close the trading controls update block correctly so the dashboard script executes without syntax errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2af911b9083208492dcaae382acf3