### PR TITLE
Handle naive timestamps when computing trade age

### DIFF
--- a/trading_bot/trade_manager.py
+++ b/trading_bot/trade_manager.py
@@ -1222,7 +1222,10 @@ def _parse_timestamp(ts: str | None) -> datetime | None:
     try:
         if ts.endswith("Z"):
             ts = ts[:-1] + "+00:00"
-        return datetime.fromisoformat(ts)
+        parsed = datetime.fromisoformat(ts)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
     except ValueError:
         logger.debug("Invalid timestamp %s", ts)
         return None
@@ -1235,6 +1238,8 @@ def trade_age_minutes(trade: dict, now: datetime | None = None) -> float | None:
         return None
     if now is None:
         now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     delta = now.astimezone(timezone.utc) - opened.astimezone(timezone.utc)
     return delta.total_seconds() / 60.0
 


### PR DESCRIPTION
### Motivation
- Evitar que `trade_age_minutes` falle al procesar timestamps ISO sin información de zona horaria normalizando a UTC durante el parseo y protegiendo el valor `now` si es un `datetime` naïve.

### Description
- Normalize parsed timestamps without `tzinfo` to UTC in `_parse_timestamp` (set `tzinfo=timezone.utc`) and ensure `now` has `tzinfo` in `trade_age_minutes` before using `astimezone`.

### Testing
- No automated tests were run for this change; no test suite was executed. You can add unit tests covering `_parse_timestamp` with timezone-less strings and `trade_age_minutes` with naïve `now` to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981056ba1748320b60c838ec7ebd7e4)